### PR TITLE
feat: implement supervisor getting microvm cpu and mem usage and add to examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -162,7 +162,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -485,7 +485,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -705,7 +705,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -917,7 +917,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -982,7 +982,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ dependencies = [
  "serde",
  "tempfile",
  "uuid",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1354,7 +1354,7 @@ dependencies = [
  "libipld-pb",
  "log",
  "multihash 0.18.1",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ checksum = "77d98c9d1747aa5eef1cf099cd648c3fd2d235249f5fed07522aaebc348e423b"
 dependencies = [
  "byteorder",
  "libipld-core",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1393,7 +1393,7 @@ dependencies = [
  "multibase",
  "multihash 0.18.1",
  "serde",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1426,7 +1426,7 @@ dependencies = [
  "bytes",
  "libipld-core",
  "quick-protobuf",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1555,9 +1555,10 @@ dependencies = [
  "sha2",
  "signal-hook",
  "structstruck",
+ "sysinfo",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 2.0.1",
  "tokio",
  "toml 0.8.19",
  "tracing",
@@ -1583,7 +1584,7 @@ dependencies = [
  "monoutils-store",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.1",
  "tokio",
  "typed-path",
 ]
@@ -1614,7 +1615,7 @@ dependencies = [
  "lru",
  "serde",
  "serde_ipld_dagcbor",
- "thiserror",
+ "thiserror 2.0.1",
  "tokio",
  "tokio-util",
 ]
@@ -1700,6 +1701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,7 +1749,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1777,7 +1787,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1925,7 +1935,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.65",
  "toml 0.5.11",
 ]
 
@@ -1972,7 +1982,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2092,7 +2102,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2195,7 +2205,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror",
+ "thiserror 1.0.65",
  "tower-service",
 ]
 
@@ -2396,7 +2406,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2574,7 +2584,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2596,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2630,6 +2640,20 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -2685,7 +2709,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2694,7 +2718,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c1e40dd48a282ae8edc36c732cbc219144b87fb6a4c7316d611c6b1f06ec0c"
+dependencies = [
+ "thiserror-impl 2.0.1",
 ]
 
 [[package]]
@@ -2705,7 +2738,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874aa7e446f1da8d9c3a5c95b1c5eb41d800045252121dc7f8e0ba370cee55f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2769,7 +2813,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2897,7 +2941,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2962,7 +3006,7 @@ checksum = "560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3123,7 +3167,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -3157,7 +3201,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3228,7 +3272,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3236,6 +3280,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows"
@@ -3258,15 +3312,38 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
  "windows-strings",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3277,7 +3354,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3288,7 +3376,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3297,8 +3385,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -3317,7 +3414,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3507,7 +3604,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0"
 structstruck = "0.4"
 xattr = "1.3"
 sha2 = "0.10"
-thiserror = "1.0"
+thiserror = "2.0"
 anyhow = "1.0"
 futures = "0.3"
 tokio = { version = "1.41", features = ["full"] }

--- a/monocore/Cargo.toml
+++ b/monocore/Cargo.toml
@@ -57,6 +57,7 @@ typed-builder.workspace = true
 typed-path.workspace = true
 uuid.workspace = true
 xattr.workspace = true
+sysinfo = "0.32.0"
 
 [dev-dependencies]
 test-log.workspace = true

--- a/monocore/README.md
+++ b/monocore/README.md
@@ -1,24 +1,34 @@
+
+# Monocore Directory Structure
+
+Here is the directory structure of `MONOCORE_HOME`:
+
 ```mermaid
 graph TD
-    A[~/.monocore] --> B[monoimages/]
-    B --> C[repos/]
-    C --> D[<repo-name:tag>.cid]
-    B --> E[layers/]
+    A[~/.monocore] --> B[monoimage/]
+    B --> C[repo/]
+    C --> D["[repo-name]__[tag].cid"]
+    B --> E[layer/]
 
     A --> F[oci/]
-    F --> G[repos/]
-    G --> H[<repo-name:tag>/]
+    F --> G[repo/]
+    G --> H["[repo-name]__[tag]/"]
     H --> I[config.json]
     H --> J[manifest.json]
     H --> K[index.json]
-    F --> L[layers/]
-    L --> M[<hash>.tar.gz]
+    F --> L[layer/]
+    L --> M["[hash]"]
 
     A --> N[vms/]
-    N --> O[<repo-name:tag>/]
+    N --> O["[repo-name]__[tag]/"]
     O --> P[service.toml]
-    O --> Q[<repo-name:tag>.cid]
+    O --> Q["[repo-name]__[tag].cid"]
     O --> R[rootfs/]
 
-    S[/var/lib/monocore/services/] --> T[<pid>.<service-name>.json]
+    A --> S[run/]
+    S --> T["[service-name]__[supervisor-pid].json"]
+
+    A --> U[log/]
+    U --> V["[service-name].stderr.log"]
+    U --> W["[service-name].stdout.log"]
 ```

--- a/monocore/examples/orchestration_load.rs
+++ b/monocore/examples/orchestration_load.rs
@@ -94,24 +94,49 @@ async fn print_service_status(orchestrator: &Orchestrator) -> anyhow::Result<()>
     println!("\nService Status:");
     println!();
     println!(
-        "{:<15} {:<10} {:<10} {:<15} {:<15} {:<12} {:<14}",
-        "Service", "Group", "PID", "Status", "IP Address", "CPU Usage", "Memory Usage"
+        "{:<15} {:<10} {:<8} {:<8} {:<10} {:<10} {:<15} {:<15} {:<10} {:<10}",
+        "Service",
+        "Group",
+        "vCPUs",
+        "RAM",
+        "Sup PID",
+        "VM PID",
+        "Status",
+        "Assigned IP",
+        "CPU Usage",
+        "Mem Usage"
     );
-    println!("{:-<92}", "");
+    println!("{:-<120}", "");
 
     for status in statuses {
+        // Get supervisor PID from orchestrator's running_services map
+        let sup_pid = orchestrator
+            .get_running_services()
+            .get(status.get_name())
+            .copied()
+            .unwrap_or(0);
+
+        // Format CPU as percentage
+        let cpu_pct = (*status.get_state().get_metrics().get_cpu_usage() * 100.0).ceil();
+        // Format memory in MiB (1 MiB = 1024 * 1024 bytes)
+        let mem_mib =
+            (*status.get_state().get_metrics().get_memory_usage() as f64) / (1024.0 * 1024.0);
+
         println!(
-            "{:<15} {:<10} {:<10} {:<15} {:<15} {:<12} {:<14}",
+            "{:<15} {:<10} {:<8} {:<8} {:<10} {:<10} {:<15} {:<15} {:<10} {:<10}",
             status.get_name(),
             status.get_state().get_group().get_name(),
+            status.get_state().get_service().get_cpus(),
+            status.get_state().get_service().get_ram(),
+            sup_pid,
             status.get_pid().unwrap_or(0),
             format!("{:?}", status.get_state().get_status()),
             status
                 .get_state()
                 .get_group_ip()
                 .map_or_else(|| Ipv4Addr::LOCALHOST, |ip| ip),
-            status.get_state().get_metrics().get_cpu_usage(),
-            status.get_state().get_metrics().get_memory_usage()
+            format!("{}%", cpu_pct as u64),
+            format!("{}MiB", mem_mib.ceil() as u64)
         );
     }
     println!();

--- a/monocore/lib/orchestration/orchestrator.rs
+++ b/monocore/lib/orchestration/orchestrator.rs
@@ -733,6 +733,11 @@ impl Orchestrator {
             self.used_ips.remove(&ip.octets()[3]);
         }
     }
+
+    /// Gets a reference to the map of running services and their supervisor PIDs
+    pub fn get_running_services(&self) -> &HashMap<String, u32> {
+        &self.running_services
+    }
 }
 
 impl LogRetentionPolicy {

--- a/monocore/lib/runtime/state.rs
+++ b/monocore/lib/runtime/state.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use getset::{Getters, Setters};
+use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{Group, Service};
@@ -14,8 +14,12 @@ use crate::config::{Group, Service};
 //--------------------------------------------------------------------------------------------------
 
 /// The state of the micro VM sub process.
-#[derive(Debug, Clone, Getters, Setters, Serialize, Deserialize)]
-#[getset(get = "pub with_prefix", set = "pub with_prefix")]
+#[derive(Debug, Clone, Getters, Setters, MutGetters, Serialize, Deserialize)]
+#[getset(
+    get = "pub with_prefix",
+    set = "pub with_prefix",
+    get_mut = "pub with_prefix"
+)]
 pub struct MicroVmState {
     /// The process ID of the micro VM sub process.
     pid: Option<u32>,
@@ -74,13 +78,19 @@ pub enum MicroVmStatus {
 }
 
 /// The metrics of the micro VM sub process.
-#[derive(Debug, Clone, Default, Getters, Setters, PartialEq, Serialize, Deserialize)]
-#[getset(get = "pub with_prefix", set = "pub with_prefix")]
+#[derive(
+    Debug, Clone, Default, Getters, Setters, MutGetters, PartialEq, Serialize, Deserialize,
+)]
+#[getset(
+    get = "pub with_prefix",
+    set = "pub with_prefix",
+    get_mut = "pub with_prefix"
+)]
 pub struct MicroVmMetrics {
-    /// The CPU usage of the micro VM.
-    cpu_usage: f64,
+    /// The CPU usage of the micro VM process in percentage.
+    cpu_usage: f32,
 
-    /// The memory usage of the micro VM.
+    /// The memory usage of the micro VM process in bytes.
     memory_usage: u64,
 }
 


### PR DESCRIPTION
This PR enhances the service status display in the orchestration examples by adding CPU and memory metrics monitoring, along with allocated resource information.

## Changes

### Metrics Collection and Display
- Added real-time CPU usage monitoring using sysinfo
- Added memory usage monitoring in bytes
- Format CPU usage as percentage (e.g. "10%")
- Format memory usage in MiB (e.g. "168MiB")
- Added columns for allocated vCPUs and RAM

### State Management
- Made MicroVmState thread-safe using Arc<Mutex>
- Added mutable getters for metrics updates
- Changed CPU usage type from f64 to f32 to match sysinfo
- Added documentation for metrics fields

### Service Configuration
- Added explicit RAM allocation in examples (200MB per service)
- Improved status display formatting and column alignment
- Added supervisor PID tracking and display

## Testing
- Tested with both basic and load orchestration examples
- Verified metrics update every 2 seconds
- Confirmed proper cleanup of metrics monitoring on service shutdown