### PR TITLE
feat: download image layers and artifacts in appropriate folders

### DIFF
--- a/monocore/README.md
+++ b/monocore/README.md
@@ -1,34 +1,171 @@
+<div align="center">
+  <h1>monocore</h1>
+  <p>Core library powering secure, sandboxed AI environments</p>
 
-# Monocore Directory Structure
+  <p>
+    <a href="https://github.com/appcypher/monocore/actions?query=">
+      <img src="https://github.com/appcypher/monocore/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    </a>
+    <a href="https://github.com/appcypher/monocore/blob/main/LICENSE">
+      <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
+    </a>
+  </p>
+</div>
 
-Here is the directory structure of `MONOCORE_HOME`:
+**`monocore`** is the engine behind the monocore platform, providing a robust foundation for running AI workloads in isolated microVMs. It handles everything from VM lifecycle management to OCI image distribution, making it easy to deploy and orchestrate AI agents securely.
+
+> [!WARNING]
+> This project is in early development and is not yet ready for production use.
+
+##
+
+## Outline
+
+- [Features](#features)
+- [Directory Structure](#directory-structure)
+- [Quick Start](#quick-start)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Features
+
+### 🔒 Secure by Design
+- Isolated microVM environments for each service
+- Resource constraints and limits enforcement
+- Network isolation between service groups
+
+### 🏃 Efficient Runtime
+- Fast microVM provisioning and startup
+- Minimal resource overhead
+- Optimized layer caching and sharing
+
+### 📦 OCI Integration
+- Pull images from any OCI-compliant registry
+- Smart layer management and deduplication
+- Local image caching for faster startups
+
+### 🎯 Service Orchestration
+- Dependency-aware service scheduling
+- Health monitoring and automatic recovery
+- Log rotation with configurable retention
+
+## Directory Structure
+
+The library maintains its state in `~/.monocore`:
 
 ```mermaid
 graph TD
-    A[~/.monocore] --> B[monoimage/]
-    B --> C[repo/]
-    C --> D["[repo-name]__[tag].cid"]
-    B --> E[layer/]
+    monocore_root[~/.monocore] --> monoimage[monoimage/]
+    monoimage --> monoimage_repo[repo/]
+    monoimage_repo --> monoimage_cid["[repo-name]__[tag].cid"]
+    monoimage --> monoimage_layer[layer/]
 
-    A --> F[oci/]
-    F --> G[repo/]
-    G --> H["[repo-name]__[tag]/"]
-    H --> I[config.json]
-    H --> J[manifest.json]
-    H --> K[index.json]
-    F --> L[layer/]
-    L --> M["[hash]"]
+    monocore_root --> oci[oci/]
+    oci --> oci_repo[repo/]
+    oci_repo --> oci_tag["[repo-name]__[tag]/"]
+    oci_tag --> oci_config[config.json]
+    oci_tag --> oci_manifest[manifest.json]
+    oci_tag --> oci_index[index.json]
+    oci --> oci_layer[layer/]
+    oci_layer --> oci_layer_hash["[hash]"]
 
-    A --> N[vms/]
-    N --> O["[repo-name]__[tag]/"]
-    O --> P[service.toml]
-    O --> Q["[repo-name]__[tag].cid"]
-    O --> R[rootfs/]
+    monocore_root --> microvm[microvm/]
+    microvm --> microvm_tag["[repo-name]__[tag]/"]
+    microvm --> microvm_instance["[repo-name]__[tag]__[uuid]/"]
+    microvm_tag --> microvm_service[service.toml]
+    microvm_tag --> microvm_cid["[repo-name]__[tag].cid"]
+    microvm_tag --> microvm_rootfs[rootfs/]
+    microvm_instance --> microvm_instance_rootfs[rootfs/]
 
-    A --> S[run/]
-    S --> T["[service-name]__[supervisor-pid].json"]
+    monocore_root --> run[run/]
+    run --> run_service["[service-name]__[supervisor-pid].json"]
 
-    A --> U[log/]
-    U --> V["[service-name].stderr.log"]
-    U --> W["[service-name].stdout.log"]
+    monocore_root --> log[log/]
+    log --> log_stderr["[service-name].stderr.log"]
+    log --> log_stdout["[service-name].stdout.log"]
 ```
+
+## Quick Start
+
+### Basic MicroVM
+```rust
+use monocore::vm::MicroVm;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let vm = MicroVm::builder()
+        .root_path("/path/to/rootfs")
+        .ram_mib(512)
+        .exec_path("/bin/echo")
+        .args(["Hello from microVM!"])
+        .build()?;
+
+    vm.start()?;
+    Ok(())
+}
+```
+
+### Service Orchestration
+```rust
+use monocore::{
+    config::{Group, Monocore, Service},
+    orchestration::Orchestrator,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let service = Service::builder_default()
+        .name("ai-agent")
+        .base("alpine:latest")
+        .ram(512)
+        .build();
+
+    let config = Monocore::builder()
+        .services(vec![service])
+        .groups(vec![Group::builder().name("agents").build()])
+        .build()?;
+
+    let mut orchestrator = Orchestrator::new("/path/to/rootfs", "/path/to/supervisor").await?;
+    orchestrator.up(config).await?;
+
+    Ok(())
+}
+```
+
+## Development
+
+### Prerequisites
+- Rust toolchain (1.75+)
+- libkrun development files
+
+### Building
+```bash
+# Build the library
+cargo build
+
+# Run tests
+cargo test
+
+# Try an example
+cargo run --example microvm_shell
+```
+
+### Examples
+The `examples/` directory showcases key features:
+- `microvm_shell.rs`: Basic microVM usage
+- `oci_pull.rs`: Image pulling and caching
+- `orchestration_basic.rs`: Service orchestration
+- `orchestration_load.rs`: Load testing
+
+## Contributing
+
+Please read our [Contributing Guide](../../CONTRIBUTING.md) for details on:
+- Code style and conventions
+- Commit message format
+- Pull request process
+- Testing requirements
+
+## License
+
+This project is licensed under the [Apache License 2.0](../../LICENSE).

--- a/monocore/examples/oci_pull.rs
+++ b/monocore/examples/oci_pull.rs
@@ -1,0 +1,83 @@
+//! This example demonstrates how to pull OCI images from Docker Hub using the Docker registry implementation.
+//!
+//! The example will:
+//! 1. Create a Docker registry client
+//! 2. Pull the Alpine Linux image
+//! 3. Show where the downloaded files are stored
+//!
+//! To run the example:
+//! ```bash
+//! cargo run --example oci_pull
+//! ```
+
+use monocore::{
+    oci::distribution::{DockerRegistry, OciRegistryPull},
+    utils::{OCI_LAYER_SUBDIR, OCI_REPO_SUBDIR, OCI_SUBDIR},
+};
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+//--------------------------------------------------------------------------------------------------
+// Functions: main
+//--------------------------------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing with debug level
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
+    // Create a temporary directory for this example
+    let temp_dir = tempdir()?;
+    println!("\nUsing temporary directory: {}", temp_dir.path().display());
+
+    // Create Docker registry client
+    let registry = DockerRegistry::with_path(temp_dir.path().to_path_buf());
+
+    // Pull Alpine Linux image
+    println!("\nPulling Alpine Linux image...");
+    registry
+        .pull_image("library/alpine", Some("latest"))
+        .await?;
+
+    // Show the downloaded files
+    print_oci_files(temp_dir.path().to_path_buf())?;
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: *
+//--------------------------------------------------------------------------------------------------
+
+// Helper function to print the OCI directory structure and files
+fn print_oci_files(base_path: PathBuf) -> anyhow::Result<()> {
+    let oci_dir = base_path.join(OCI_SUBDIR);
+
+    println!("\nOCI Directory Structure:");
+    println!("------------------------");
+
+    // Print repo directory contents
+    let repo_dir = oci_dir.join(OCI_REPO_SUBDIR).join("library_alpine__latest");
+    println!("\nRepository files at {}:", repo_dir.display());
+    for entry in std::fs::read_dir(&repo_dir)? {
+        let entry = entry?;
+        println!("- {}", entry.file_name().to_string_lossy());
+    }
+
+    // Print layers directory contents
+    let layers_dir = oci_dir.join(OCI_LAYER_SUBDIR);
+    println!("\nLayers at {}:", layers_dir.display());
+    for entry in std::fs::read_dir(layers_dir)? {
+        let entry = entry?;
+        println!("- {}", entry.file_name().to_string_lossy());
+    }
+
+    println!("\nNote: These files are in a temporary directory and will be deleted when the program exits.");
+    println!(
+        "      For persistent storage, use DockerRegistry::new() which stores files in ~/.monocore"
+    );
+
+    Ok(())
+}

--- a/monocore/lib/oci/distribution/traits.rs
+++ b/monocore/lib/oci/distribution/traits.rs
@@ -28,7 +28,9 @@ pub trait AuthProvider {
 /// including pulling images, fetching manifests, and fetching blobs.
 #[async_trait::async_trait]
 pub trait OciRegistryPull {
-    /// Pulls an OCI image from the specified repository.
+    /// Pulls an OCI image from the specified repository. This includes downloading
+    /// the image manifest, fetching the image configuration, and downloading the image layers.
+    ///
     /// If no tag is provided, defaults to the "latest" tag according to OCI specifications.
     async fn pull_image(
         &self,

--- a/monocore/lib/utils/conversion.rs
+++ b/monocore/lib/utils/conversion.rs
@@ -81,10 +81,10 @@ pub fn to_null_terminated_c_array(strings: &[CString]) -> Vec<*const c_char> {
 /// ```
 /// use monocore::utils::sanitize_repo_name;
 ///
-/// assert_eq!(sanitize_repo_name("library/alpine"), "library__alpine");
-/// assert_eq!(sanitize_repo_name("user/repo/name"), "user__repo__name");
+/// assert_eq!(sanitize_repo_name("library/alpine"), "library_alpine");
+/// assert_eq!(sanitize_repo_name("user/repo/name"), "user_repo_name");
 /// assert_eq!(sanitize_repo_name("my:weird@repo"), "my_weird_repo");
-/// assert_eq!(sanitize_repo_name(".hidden/repo."), "hidden__repo");
+/// assert_eq!(sanitize_repo_name(".hidden/repo."), "hidden_repo");
 /// ```
 pub fn sanitize_repo_name(repo_name: &str) -> String {
     // First replace forward slashes with double underscore

--- a/monocore/lib/utils/conversion.rs
+++ b/monocore/lib/utils/conversion.rs
@@ -67,3 +67,85 @@ pub fn to_null_terminated_c_array(strings: &[CString]) -> Vec<*const c_char> {
 
     ptrs
 }
+
+/// Sanitizes a repository name for use in file paths by replacing invalid characters
+/// with safe alternatives while maintaining readability and uniqueness.
+///
+/// ## Rules:
+/// - Replaces '/' with '__' (double underscore to avoid collisions)
+/// - Replaces other invalid path chars with '_'
+/// - Trims leading/trailing whitespace and dots
+/// - Collapses multiple consecutive separators
+///
+/// ## Examples:
+/// ```
+/// use monocore::utils::sanitize_repo_name;
+///
+/// assert_eq!(sanitize_repo_name("library/alpine"), "library__alpine");
+/// assert_eq!(sanitize_repo_name("user/repo/name"), "user__repo__name");
+/// assert_eq!(sanitize_repo_name("my:weird@repo"), "my_weird_repo");
+/// assert_eq!(sanitize_repo_name(".hidden/repo."), "hidden__repo");
+/// ```
+pub fn sanitize_repo_name(repo_name: &str) -> String {
+    // First replace forward slashes with double underscore
+    let with_safe_slashes = repo_name.replace('/', "__");
+
+    // Replace other invalid chars with single underscore
+    let sanitized = with_safe_slashes
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    // Trim leading/trailing dots and whitespace
+    let trimmed: &str = sanitized.trim_matches(|c: char| c == '.' || c.is_whitespace());
+
+    // Collapse multiple consecutive separators
+    trimmed
+        .split('_')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_repo_name() {
+        // Test basic repository names
+        assert_eq!(sanitize_repo_name("library/alpine"), "library_alpine");
+        assert_eq!(sanitize_repo_name("user/repo/name"), "user_repo_name");
+
+        // Test special characters
+        assert_eq!(sanitize_repo_name("my:weird@repo"), "my_weird_repo");
+        assert_eq!(sanitize_repo_name("repo#with$chars"), "repo_with_chars");
+
+        // Test leading/trailing characters
+        assert_eq!(sanitize_repo_name(".hidden/repo."), "hidden_repo");
+        assert_eq!(sanitize_repo_name(" spaces /repo "), "spaces_repo");
+
+        // Test multiple consecutive separators
+        assert_eq!(
+            sanitize_repo_name("multiple___underscores"),
+            "multiple_underscores"
+        );
+        assert_eq!(sanitize_repo_name("weird////slashes"), "weird_slashes");
+
+        // Test mixed cases
+        assert_eq!(
+            sanitize_repo_name("my.weird/repo@with/special:chars"),
+            "my_weird_repo_with_special_chars"
+        );
+    }
+}

--- a/monocore/lib/utils/path.rs
+++ b/monocore/lib/utils/path.rs
@@ -9,14 +9,26 @@ use super::MONOCORE_HOME_ENV_VAR;
 /// The sub directory where monocore artifacts, configs, etc are stored.
 pub const MONOCORE_SUBDIR: &str = ".monocore";
 
-/// The OCI sub directory.
+/// The OCI sub directory where the OCI image layers, index, configurations, etc are stored.
 pub const OCI_SUBDIR: &str = "oci";
 
 /// The sub directory where monocore OCI image layers are cached.
-pub const IMAGE_LAYERS_SUBDIR: &str = "layers";
+pub const OCI_LAYER_SUBDIR: &str = "layer";
 
 /// The sub directory where monocore OCI image index, configurations, etc. are cached.
-pub const IMAGE_REPOS_SUBDIR: &str = "repos";
+pub const OCI_REPO_SUBDIR: &str = "repo";
+
+/// The filename for the OCI image index JSON file
+pub const OCI_INDEX_FILENAME: &str = "index.json";
+
+/// The filename for the OCI image manifest JSON file
+pub const OCI_MANIFEST_FILENAME: &str = "manifest.json";
+
+/// The filename for the OCI image config JSON file
+pub const OCI_CONFIG_FILENAME: &str = "config.json";
+
+/// The microvm sub directory where the rootfs and other related files associated with the microvm are stored.
+pub const MICROVM_SUBDIR: &str = "microvm";
 
 /// The sub directory where runtime state is stored.
 pub const STATE_SUBDIR: &str = "run";


### PR DESCRIPTION
This PR enhances OCI image handling and improves documentation across the monocore library.

## Changes

### OCI Image Handling
- Add new `oci_pull.rs` example demonstrating OCI image pulling functionality
- Implement proper file structure for OCI artifacts with separate directories for repos and layers
- Add file path sanitization for repository names
- Improve error handling and validation in image pulling process

### Directory Structure
- Standardize directory naming conventions (e.g., `layer/` instead of `layers/`)
- Add constants for common filenames (`index.json`, `manifest.json`, `config.json`)
- Document complete directory structure in README with mermaid diagram

### Documentation
- Revamp monocore README with comprehensive feature overview
- Add detailed code examples for common use cases
- Include badges and warning about development status
- Improve API documentation with more detailed descriptions

### Testing
- Add integration tests for OCI image pulling
- Add unit tests for repository name sanitization
- Use temporary directories in tests to avoid filesystem pollution

## Testing Done
- Ran all unit tests and integration tests
- Manually tested OCI image pulling with Alpine Linux image
- Verified directory structure creation and file handling
- Checked documentation rendering

## Notes
- The OCI implementation now follows the OCI Distribution Specification more closely
- All file operations are now properly handled with async I/O
- Directory structure is now consistent with the rest of the project