### PR TITLE
refactor(orchestrator): reorganize code and improve service management

### DIFF
--- a/monocore/README.md
+++ b/monocore/README.md
@@ -83,6 +83,11 @@ graph TD
     rootfs_ref --> rootfs_ref_repo["[repo-name]__[tag]/"]
     rootfs_ref_repo --> rootfs_ref_repo_merged[merged/]
 
+    monocore_root --> service[service/]
+    service --> service_info["[service-name]/"]
+    service_info --> service_json[service.json]
+    service_info --> group_json[group.json]
+
     monocore_root --> run[run/]
     run --> run_service["[service-name]__[pid].json"]
 
@@ -146,19 +151,84 @@ async fn main() -> anyhow::Result<()> {
 
 - Rust toolchain (1.75+)
 - libkrun (see [monocore/README.md](http://github.com/appcypher/monocore#setup))
-- Linux OS for full functionality (OverlayFS support)
-  - macOS users should use Docker Desktop or a Linux VM for development
+- Linux OS / macOS
 
-### Examples
+### Running Examples
 
-The `examples/` directory showcases key features:
+The `examples/` directory contains several examples demonstrating key features. Use `make example <name>` to run them:
 
-- `microvm_shell.rs`: Basic microVM usage
-- `oci_pull.rs`: Image pulling and caching
-- `orchestration_basic.rs`: Service orchestration
-- `orchestration_load.rs`: Load testing
+```bash
+# Basic MicroVM Examples
+make example microvm_shell     # Interactive shell in MicroVM
+make example microvm_nop       # Simple no-op MicroVM
 
-Check the top of each file for usage instructions.
+# Networking Examples
+make example microvm_curl [-- --local-only] [-- <target>]  # HTTP requests from MicroVM
+make example microvm_tcp -- --server                       # TCP server (port 3456)
+make example microvm_tcp                                   # TCP client
+make example microvm_udp -- --server                       # UDP server
+make example microvm_udp                                   # UDP client
+
+# OCI Image Examples
+make example oci_pull          # Pull images from Docker Hub
+make example oci_merge         # Merge image layers with OverlayFS
+
+# Orchestration Examples
+make example orchestration_basic   # Basic service management
+make example orchestration_load    # Service state persistence
+```
+
+### Using the CLI
+
+The monocore CLI provides commands for managing services and container images. Use `make bin monocore` to run CLI commands:
+
+```bash
+# View available commands
+make bin monocore -- --help
+
+# Service Management
+make bin monocore -- up -f monocore.toml              # Start services
+make bin monocore -- up -f monocore.toml -g mygroup   # Start specific group
+make bin monocore -- down                             # Stop all services
+make bin monocore -- down -g mygroup                  # Stop specific group
+make bin monocore -- status                           # Show service status
+
+# Image Management
+make bin monocore -- pull alpine:latest               # Pull image
+make bin monocore -- remove service1 service2         # Remove services
+make bin monocore -- remove -g mygroup                # Remove group
+
+# Debug Options
+make bin monocore -- --verbose <command>              # Enable verbose logging
+```
+
+### Example Details
+
+The examples demonstrate different aspects of monocore's functionality:
+
+- **MicroVM Examples**
+  - `microvm_shell.rs`: Interactive shell with 2 vCPUs, 1024MB RAM
+  - `microvm_curl.rs`: Network requests with configurable restrictions
+  - `microvm_tcp.rs`: TCP networking between microVMs
+  - `microvm_udp.rs`: UDP communication between microVMs
+  - `microvm_nop.rs`: Minimal no-operation example
+
+- **OCI Examples**
+  - `oci_pull.rs`: Docker Hub image pulling and caching
+  - `oci_merge.rs`: Layer merging with OverlayFS demonstration
+
+- **Orchestration Examples**
+  - `orchestration_basic.rs`: Service lifecycle management
+  - `orchestration_load.rs`: Service state persistence and recovery
+
+Each example contains detailed usage instructions in its source file comments.
+
+### Development Tips
+
+- Use `RUST_BACKTRACE=1` for detailed error traces
+- On macOS, examples are automatically signed with entitlements
+- The build directory (`~/.monocore`) contains logs and service state
+- Check service logs in `~/.monocore/log/` for debugging
 
 ## License
 

--- a/monocore/examples/microvm_curl.rs
+++ b/monocore/examples/microvm_curl.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
     // Use specific directories for OCI and rootfs
     let build_dir = format!("{}/build", env!("CARGO_MANIFEST_DIR"));
     let oci_dir = format!("{}/oci", build_dir);
-    let rootfs_fedora_dir = format!("{}/reference/library_fedora__latest", build_dir);
+    let rootfs_fedora_dir = format!("{}/rootfs/reference/library_fedora__latest", build_dir);
 
     // Pull and merge Fedora image
     utils::pull_docker_image(&oci_dir, "library/fedora:latest").await?;

--- a/monocore/examples/microvm_nop.rs
+++ b/monocore/examples/microvm_nop.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     // Use specific directories for OCI and rootfs
     let build_dir = format!("{}/build", env!("CARGO_MANIFEST_DIR"));
     let oci_dir = format!("{}/oci", build_dir);
-    let rootfs_alpine_dir = format!("{}/reference/library_alpine__latest", build_dir);
+    let rootfs_alpine_dir = format!("{}/rootfs/reference/library_alpine__latest", build_dir);
 
     // Pull and merge Alpine image
     utils::pull_docker_image(&oci_dir, "library/alpine:latest").await?;

--- a/monocore/examples/microvm_shell.rs
+++ b/monocore/examples/microvm_shell.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     // Use specific directories for OCI and rootfs
     let build_dir = format!("{}/build", env!("CARGO_MANIFEST_DIR"));
     let oci_dir = format!("{}/oci", build_dir);
-    let rootfs_alpine_dir = format!("{}/reference/library_alpine__latest", build_dir);
+    let rootfs_alpine_dir = format!("{}/rootfs/reference/library_alpine__latest", build_dir);
 
     // Pull and merge Alpine image
     utils::pull_docker_image(&oci_dir, "library/alpine:latest").await?;

--- a/monocore/examples/microvm_tcp.rs
+++ b/monocore/examples/microvm_tcp.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     // Use specific directories for OCI and rootfs
     let build_dir = format!("{}/build", env!("CARGO_MANIFEST_DIR"));
     let oci_dir = format!("{}/oci", build_dir);
-    let rootfs_alpine_dir = format!("{}/reference/library_alpine__latest", build_dir);
+    let rootfs_alpine_dir = format!("{}/rootfs/reference/library_alpine__latest", build_dir);
 
     // Pull and merge Alpine image
     utils::pull_docker_image(&oci_dir, "library/alpine:latest").await?;

--- a/monocore/examples/microvm_udp.rs
+++ b/monocore/examples/microvm_udp.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     // Use specific directories for OCI and rootfs
     let build_dir = format!("{}/build", env!("CARGO_MANIFEST_DIR"));
     let oci_dir = format!("{}/oci", build_dir);
-    let rootfs_alpine_dir = format!("{}/reference/library_alpine__latest", build_dir);
+    let rootfs_alpine_dir = format!("{}/rootfs/reference/library_alpine__latest", build_dir);
 
     // Pull and merge Alpine image
     utils::pull_docker_image(&oci_dir, "library/alpine:latest").await?;

--- a/monocore/examples/orchestration_basic.rs
+++ b/monocore/examples/orchestration_basic.rs
@@ -44,7 +44,6 @@ async fn main() -> anyhow::Result<()> {
     let oci_dir = format!("{}/oci", build_dir);
     let rootfs_dir = format!("{}/rootfs", build_dir);
     let rootfs_alpine_dir = format!("{}/reference/library_alpine__latest", rootfs_dir);
-    let rootfs_service_dir = format!("{}/service", rootfs_dir);
 
     // Pull and merge Alpine image
     utils::pull_docker_image(&oci_dir, "library/alpine:latest").await?;
@@ -57,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create orchestrator with log retention policy
     let mut orchestrator = Orchestrator::with_log_retention_policy(
-        rootfs_service_dir,
+        build_dir,
         supervisor_path,
         LogRetentionPolicy::with_max_age_weeks(1),
     )

--- a/monocore/lib/cli/args.rs
+++ b/monocore/lib/cli/args.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use tracing::Level;
 
-use crate::utils::{MONOCORE_OCI_DIR, MONOCORE_ROOTFS_DIR};
+use crate::utils::DEFAULT_MONOCORE_HOME;
 
 use super::styles;
 
@@ -38,13 +38,9 @@ pub enum MonocoreSubcommand {
         #[arg(short, long)]
         group: Option<String>,
 
-        /// Directory for OCI images
-        #[arg(long, default_value = MONOCORE_OCI_DIR.as_os_str())]
-        oci_dir: PathBuf,
-
-        /// Directory for merged root filesystems
-        #[arg(long, default_value = MONOCORE_ROOTFS_DIR.as_os_str())]
-        rootfs_dir: PathBuf,
+        /// Home directory for monocore state (default: ~/.monocore)
+        #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]
+        home_dir: PathBuf,
     },
 
     /// Stop running services. If group specified, only stops services in that group
@@ -57,25 +53,41 @@ pub enum MonocoreSubcommand {
         #[arg(short, long)]
         group: Option<String>,
 
-        /// Directory containing service root filesystems
-        #[arg(long, default_value = MONOCORE_ROOTFS_DIR.as_os_str())]
-        rootfs_dir: PathBuf,
+        /// Home directory for monocore state (default: ~/.monocore)
+        #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]
+        home_dir: PathBuf,
     },
 
     /// Pull container image from registry
     #[command(arg_required_else_help = true)]
     Pull {
-        /// Image reference (e.g. 'ubuntu:22.04')
+        /// Image reference (e.g. 'alpine:latest')
         #[arg(required = true)]
         image: String,
 
-        /// Directory for OCI images
-        #[arg(long, default_value = MONOCORE_OCI_DIR.as_os_str())]
-        oci_dir: PathBuf,
+        /// Home directory for monocore state (default: ~/.monocore)
+        #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]
+        home_dir: PathBuf,
     },
 
     /// Show status of running services (CPU, memory, network, etc)
     Status {},
+
+    /// Remove service files (rootfs and config)
+    #[command(alias = "rm", arg_required_else_help = true)]
+    Remove {
+        /// Names of services to remove
+        #[arg(required_unless_present = "group")]
+        services: Vec<String>,
+
+        /// Remove all services in this group
+        #[arg(short, long)]
+        group: Option<String>,
+
+        /// Home directory for monocore state (default: ~/.monocore)
+        #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]
+        home_dir: PathBuf,
+    },
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/monocore/lib/error.rs
+++ b/monocore/lib/error.rs
@@ -210,6 +210,14 @@ pub enum MonocoreError {
     /// An error that occurred when parsing an image reference
     #[error("invalid image reference: {0}")]
     ImageReferenceError(String),
+
+    /// An error that occurred when trying to remove running services
+    #[error("Cannot remove running services: {0}")]
+    ServiceStillRunning(String),
+
+    /// An error that occurred when invalid command line arguments were provided
+    #[error("{0}")]
+    InvalidArgument(String),
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/monocore/lib/orchestration/down.rs
+++ b/monocore/lib/orchestration/down.rs
@@ -1,0 +1,116 @@
+use std::{collections::HashSet, time::Duration};
+
+use tokio::time;
+
+use crate::{orchestration::utils, MonocoreResult};
+
+use super::Orchestrator;
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Orchestrator {
+    /// Stops running services and removes them from the configuration.
+    /// When service_name is None, stops and removes all services.
+    pub async fn down(&mut self, service_name: Option<&str>) -> MonocoreResult<()> {
+        if self.log_retention_policy.auto_cleanup {
+            if let Err(e) = self.cleanup_old_logs().await {
+                tracing::warn!("Failed to clean up old logs during shutdown: {}", e);
+            }
+        }
+
+        // Get the services to stop
+        let services_to_stop: HashSet<String> = match service_name {
+            Some(name) => vec![name.to_string()].into_iter().collect(),
+            None => self.running_services.keys().cloned().collect(),
+        };
+
+        // Get all services in dependency order (reversed for shutdown)
+        let ordered_services: Vec<_> = self
+            .config
+            .get_ordered_services()
+            .into_iter()
+            .filter(|s| services_to_stop.contains(s.get_name()))
+            .rev() // Reverse the order for shutdown
+            .collect();
+
+        // Clone the ordered services to avoid borrow issues
+        let ordered_services: Vec<_> = ordered_services.into_iter().cloned().collect();
+
+        // Clone ordered_services before using it
+        let services_for_groups = ordered_services.clone();
+
+        // Stop services in reverse dependency order
+        for service in ordered_services {
+            let service_name = service.get_name();
+
+            // Stop the service if it's running
+            if let Some(pid) = self.running_services.remove(service_name) {
+                tracing::info!(
+                    "Stopping supervisor for service {} (PID {})",
+                    service_name,
+                    pid
+                );
+
+                if let Err(e) = self.stop_service(pid).await {
+                    tracing::error!("Failed to send SIGTERM to service {}: {}", service_name, e);
+                    continue;
+                }
+
+                // Wait for process to exit gracefully with timeout
+                let mut attempts = 5;
+                while attempts > 0 && utils::is_process_running(pid).await {
+                    time::sleep(Duration::from_secs(2)).await;
+                    attempts -= 1;
+                }
+
+                if utils::is_process_running(pid).await {
+                    tracing::warn!(
+                        "Service {} (PID {}) did not exit within timeout period",
+                        service_name,
+                        pid
+                    );
+                }
+            }
+        }
+
+        // Convert HashSet back to Vec for remove_services
+        let services_to_stop: Vec<_> = services_to_stop.into_iter().collect();
+
+        // Remove services from config in place
+        self.config.remove_services(Some(&services_to_stop));
+
+        // Get groups that will have no running services after shutdown
+        let mut empty_groups = HashSet::new();
+        for service in services_for_groups.iter() {
+            let group_name = service.get_group().unwrap_or_default();
+            let group_has_other_services = self.running_services.keys().any(|name| {
+                name != service.get_name()
+                    && self
+                        .config
+                        .get_service(name)
+                        .map(|s| s.get_group().unwrap_or_default() == group_name)
+                        .unwrap_or(false)
+            });
+            if !group_has_other_services {
+                empty_groups.insert(group_name);
+            }
+        }
+
+        // Release IPs for groups with no running services
+        for group_name in empty_groups {
+            self.release_group_ip(group_name);
+        }
+
+        Ok(())
+    }
+
+    /// Releases an IP address assigned to a group, making it available for reuse.
+    /// This should be called when a group no longer has any running services.
+    pub(super) fn release_group_ip(&mut self, group_name: &str) {
+        if let Some(ip) = self.assigned_ips.remove(group_name) {
+            self.used_ips.remove(&ip.octets()[3]);
+        }
+    }
+}

--- a/monocore/lib/orchestration/log_policy.rs
+++ b/monocore/lib/orchestration/log_policy.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use crate::config::DEFAULT_LOG_MAX_AGE;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for managing log file retention and cleanup in the orchestrator.
+///
+/// This configuration controls:
+/// - How long log files are retained before being eligible for deletion
+/// - Whether cleanup happens automatically during service lifecycle operations
+#[derive(Debug, Clone)]
+pub struct LogRetentionPolicy {
+    /// Maximum age of log files before they are eligible for deletion.
+    /// Files older than this duration will be removed during cleanup operations.
+    pub(super) max_age: Duration,
+
+    /// Whether to automatically clean up logs during service lifecycle operations (up/down).
+    /// When true, old log files will be cleaned up during service start and stop operations.
+    /// When false, cleanup must be triggered manually via `cleanup_old_logs()`.
+    pub(super) auto_cleanup: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl LogRetentionPolicy {
+    /// Creates a new log retention policy with custom settings.
+    pub fn new(max_age: Duration, auto_cleanup: bool) -> Self {
+        Self {
+            max_age,
+            auto_cleanup,
+        }
+    }
+
+    /// Creates a new policy that retains logs for the specified number of hours.
+    pub fn with_max_age_hours(hours: u64) -> Self {
+        Self {
+            max_age: Duration::from_secs(hours * 60 * 60),
+            auto_cleanup: true,
+        }
+    }
+
+    /// Creates a new policy that retains logs for the specified number of days.
+    pub fn with_max_age_days(days: u64) -> Self {
+        Self {
+            max_age: Duration::from_secs(days * 24 * 60 * 60),
+            auto_cleanup: true,
+        }
+    }
+
+    /// Creates a new policy that retains logs for the specified number of weeks.
+    pub fn with_max_age_weeks(weeks: u64) -> Self {
+        Self {
+            max_age: Duration::from_secs(weeks * 7 * 24 * 60 * 60),
+            auto_cleanup: true,
+        }
+    }
+
+    /// Creates a new policy that retains logs for the specified number of months.
+    /// Note: Uses a 30-day approximation for months.
+    pub fn with_max_age_months(months: u64) -> Self {
+        Self {
+            max_age: Duration::from_secs(months * 30 * 24 * 60 * 60),
+            auto_cleanup: true,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for LogRetentionPolicy {
+    /// Creates a default configuration that:
+    /// - Keeps logs for 7 days
+    /// - Enables automatic cleanup during service operations
+    fn default() -> Self {
+        Self {
+            max_age: DEFAULT_LOG_MAX_AGE,
+            auto_cleanup: true,
+        }
+    }
+}

--- a/monocore/lib/orchestration/mod.rs
+++ b/monocore/lib/orchestration/mod.rs
@@ -1,10 +1,16 @@
 //! The orchestration module of the monocore.
 
+mod down;
+mod log_policy;
 mod orchestrator;
+mod remove;
+mod status;
+mod up;
 mod utils;
 
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use log_policy::*;
 pub use orchestrator::*;

--- a/monocore/lib/orchestration/orchestrator.rs
+++ b/monocore/lib/orchestration/orchestrator.rs
@@ -1,29 +1,27 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     net::Ipv4Addr,
     path::{Path, PathBuf},
-    process::Stdio,
     time::{Duration, SystemTime},
 };
 
 use getset::Getters;
 use tokio::{
     fs::{self, DirEntry},
-    io::{AsyncBufReadExt, BufReader},
-    process::{Child, Command},
-    time,
+    process::Command,
 };
-use tracing::{error, info, warn};
 
 use crate::{
-    config::{Monocore, Service, DEFAULT_LOG_MAX_AGE},
-    oci::rootfs,
+    config::{Monocore, Service},
     runtime::MicroVmState,
-    utils::{MERGED_SUBDIR, MONOCORE_LOG_DIR, MONOCORE_STATE_DIR, REFERENCE_SUBDIR},
+    utils::{MONOCORE_LOG_DIR, MONOCORE_STATE_DIR},
     MonocoreError, MonocoreResult,
 };
 
-use super::utils::{self, LoadedState};
+use super::{
+    utils::{self, LoadedState},
+    LogRetentionPolicy,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -32,44 +30,29 @@ use super::utils::{self, LoadedState};
 /// The Orchestrator manages the lifecycle of monocore services, handling their startup, shutdown,
 /// and monitoring. It coordinates multiple supervised services and provides status information
 /// about their operation. It also manages log file cleanup based on configured policies.
+#[derive(Debug, Getters)]
+#[getset(get = "pub with_prefix")]
 pub struct Orchestrator {
     /// The monocore configuration.
-    config: Monocore,
+    pub(super) config: Monocore,
 
-    /// The path to the directory containing service rootfs directories
-    services_rootfs_dir: PathBuf,
+    /// The path to the directory containing rootfs directories and service configuration files
+    pub(super) home_dir: PathBuf,
 
     /// The path to the supervisor executable.
-    supervisor_exe_path: PathBuf,
+    pub(super) supervisor_exe_path: PathBuf,
 
     /// Map of running services and their process IDs.
-    running_services: HashMap<String, u32>,
+    pub(super) running_services: HashMap<String, u32>,
 
     /// Configuration for log retention and cleanup
-    log_retention_policy: LogRetentionPolicy,
+    pub(super) log_retention_policy: LogRetentionPolicy,
 
     /// Maps group name to assigned IP
-    assigned_ips: HashMap<String, Ipv4Addr>,
+    pub(super) assigned_ips: HashMap<String, Ipv4Addr>,
 
     /// Tracks used last octets for IP assignment
-    used_ips: BTreeSet<u8>,
-}
-
-/// Configuration for managing log file retention and cleanup in the orchestrator.
-///
-/// This configuration controls:
-/// - How long log files are retained before being eligible for deletion
-/// - Whether cleanup happens automatically during service lifecycle operations
-#[derive(Debug, Clone)]
-pub struct LogRetentionPolicy {
-    /// Maximum age of log files before they are eligible for deletion.
-    /// Files older than this duration will be removed during cleanup operations.
-    max_age: Duration,
-
-    /// Whether to automatically clean up logs during service lifecycle operations (up/down).
-    /// When true, old log files will be cleaned up during service start and stop operations.
-    /// When false, cleanup must be triggered manually via `cleanup_old_logs()`.
-    auto_cleanup: bool,
+    pub(super) used_ips: BTreeSet<u8>,
 }
 
 /// Status information for a service.
@@ -93,7 +76,7 @@ pub struct ServiceStatus {
 impl Orchestrator {
     /// Creates a new Orchestrator instance with custom log retention policy
     pub async fn with_log_retention_policy(
-        services_rootfs_dir: impl AsRef<Path>,
+        home_dir: impl AsRef<Path>,
         supervisor_exe_path: impl AsRef<Path>,
         log_retention_policy: LogRetentionPolicy,
     ) -> MonocoreResult<Self> {
@@ -110,7 +93,7 @@ impl Orchestrator {
 
         Ok(Self {
             config: Monocore::default(),
-            services_rootfs_dir: services_rootfs_dir.as_ref().to_path_buf(),
+            home_dir: home_dir.as_ref().to_path_buf(),
             supervisor_exe_path,
             running_services: HashMap::new(),
             log_retention_policy,
@@ -121,463 +104,22 @@ impl Orchestrator {
 
     /// Creates a new Orchestrator instance with default log retention policy
     pub async fn new(
-        services_rootfs_dir: impl AsRef<Path>,
+        home_dir: impl AsRef<Path>,
         supervisor_exe_path: impl AsRef<Path>,
     ) -> MonocoreResult<Self> {
         Self::with_log_retention_policy(
-            services_rootfs_dir,
+            home_dir,
             supervisor_exe_path,
             LogRetentionPolicy::default(),
         )
         .await
     }
 
-    /// Starts or updates services according to the provided configuration.
-    /// Merges the new config with existing config and starts/restarts changed services.
-    pub async fn up(&mut self, new_config: Monocore) -> MonocoreResult<()> {
-        if self.log_retention_policy.auto_cleanup {
-            if let Err(e) = self.cleanup_old_logs().await {
-                warn!("Failed to clean up old logs during startup: {}", e);
-            }
-        }
-
-        // Clone current config to avoid borrowing issues
-        let current_config = self.config.clone();
-
-        // Get the services that changed or were added
-        let changed_services: HashSet<_> = current_config
-            .get_changed_services(&new_config)
-            .into_iter()
-            .map(|s| s.get_name().to_string())
-            .collect();
-
-        // Merge the configurations
-        self.config = current_config.merge(&new_config)?;
-
-        // Get ordered list of changed services based on dependencies
-        let ordered_services: Vec<_> = self
-            .config
-            .get_ordered_services()
-            .into_iter()
-            .filter(|s| changed_services.contains(s.get_name()))
-            .collect();
-
-        // Clone the ordered services to avoid borrow issues
-        let ordered_services: Vec<_> = ordered_services.into_iter().cloned().collect();
-
-        // Start/restart changed services in dependency order
-        for service in ordered_services {
-            // Stop the service if it's running
-            if let Some(pid) = self.running_services.get(service.get_name()) {
-                let pid = *pid; // Copy the pid to avoid borrow issues
-                self.stop_service(pid).await?;
-                self.running_services.remove(service.get_name());
-            }
-
-            // Start the service with new configuration
-            self.start_service(&service).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Stops running services and removes them from the configuration.
-    /// When service_name is None, stops and removes all services.
-    pub async fn down(&mut self, service_name: Option<&str>) -> MonocoreResult<()> {
-        if self.log_retention_policy.auto_cleanup {
-            if let Err(e) = self.cleanup_old_logs().await {
-                warn!("Failed to clean up old logs during shutdown: {}", e);
-            }
-        }
-
-        // Get the services to stop
-        let services_to_stop: HashSet<String> = match service_name {
-            Some(name) => vec![name.to_string()].into_iter().collect(),
-            None => self.running_services.keys().cloned().collect(),
-        };
-
-        // Get all services in dependency order (reversed for shutdown)
-        let ordered_services: Vec<_> = self
-            .config
-            .get_ordered_services()
-            .into_iter()
-            .filter(|s| services_to_stop.contains(s.get_name()))
-            .rev() // Reverse the order for shutdown
-            .collect();
-
-        // Clone the ordered services to avoid borrow issues
-        let ordered_services: Vec<_> = ordered_services.into_iter().cloned().collect();
-
-        // Clone ordered_services before using it
-        let services_for_groups = ordered_services.clone();
-
-        // Stop services in reverse dependency order
-        for service in ordered_services {
-            let service_name = service.get_name();
-
-            // Stop the service if it's running
-            if let Some(pid) = self.running_services.remove(service_name) {
-                info!(
-                    "Stopping supervisor for service {} (PID {})",
-                    service_name, pid
-                );
-
-                if let Err(e) = self.stop_service(pid).await {
-                    error!("Failed to send SIGTERM to service {}: {}", service_name, e);
-                    continue;
-                }
-
-                // Wait for process to exit gracefully with timeout
-                let mut attempts = 5;
-                while attempts > 0 && utils::is_process_running(pid).await {
-                    time::sleep(Duration::from_secs(2)).await;
-                    attempts -= 1;
-                }
-
-                if utils::is_process_running(pid).await {
-                    warn!(
-                        "Service {} (PID {}) did not exit within timeout period",
-                        service_name, pid
-                    );
-                }
-            }
-        }
-
-        // Convert HashSet back to Vec for remove_services
-        let services_to_stop: Vec<_> = services_to_stop.into_iter().collect();
-
-        // Remove services from config in place
-        self.config.remove_services(Some(&services_to_stop));
-
-        // Get groups that will have no running services after shutdown
-        let mut empty_groups = HashSet::new();
-        for service in services_for_groups.iter() {
-            let group_name = service.get_group().unwrap_or_default();
-            let group_has_other_services = self.running_services.keys().any(|name| {
-                name != service.get_name()
-                    && self
-                        .config
-                        .get_service(name)
-                        .map(|s| s.get_group().unwrap_or_default() == group_name)
-                        .unwrap_or(false)
-            });
-            if !group_has_other_services {
-                empty_groups.insert(group_name);
-            }
-        }
-
-        // Release IPs for groups with no running services
-        for group_name in empty_groups {
-            self.release_group_ip(group_name);
-        }
-
-        Ok(())
-    }
-
-    /// Retrieves the current status of all services, including their process IDs and state
-    /// information. Also identifies and cleans up stale state files for processes that are
-    /// no longer running.
-    pub async fn status(&self) -> MonocoreResult<Vec<ServiceStatus>> {
-        let mut statuses = Vec::new();
-        let mut stale_files = Vec::new();
-
-        // Ensure directory exists before reading
-        if !fs::try_exists(&*MONOCORE_STATE_DIR).await? {
-            fs::create_dir_all(&*MONOCORE_STATE_DIR).await?;
-            return Ok(statuses);
-        }
-
-        // Read all state files from the state directory
-        let mut dir = fs::read_dir(&*MONOCORE_STATE_DIR).await?;
-        while let Some(entry) = dir.next_entry().await? {
-            let path = entry.path();
-            if path.is_file() && path.extension().map_or(false, |ext| ext == "json") {
-                match fs::read_to_string(&path).await {
-                    Ok(contents) => match serde_json::from_str::<MicroVmState>(&contents) {
-                        Ok(state) => {
-                            // Check if the process is still running
-                            if let Some(pid) = state.get_pid() {
-                                if !utils::is_process_running(*pid).await {
-                                    stale_files.push(path);
-                                    continue;
-                                }
-                            }
-
-                            statuses.push(ServiceStatus {
-                                name: state.get_service().get_name().to_string(),
-                                pid: *state.get_pid(),
-                                state,
-                            });
-                        }
-                        Err(e) => {
-                            error!("Failed to parse state file {:?}: {}", path, e);
-                            stale_files.push(path);
-                        }
-                    },
-                    Err(e) => {
-                        error!("Failed to read state file {:?}: {}", path, e);
-                        stale_files.push(path);
-                    }
-                }
-            }
-        }
-
-        // Clean up stale files
-        for path in stale_files {
-            if let Err(e) = fs::remove_file(&path).await {
-                warn!("Failed to remove stale state file {:?}: {}", path, e);
-            }
-        }
-
-        Ok(statuses)
-    }
-
-    /// Starts a single service by spawning a supervisor process.
-    /// Handles IP assignment for the service's group and passes the IP through
-    /// to the supervisor and microvm processes.
-    async fn start_service(&mut self, service: &Service) -> MonocoreResult<()> {
-        if self.running_services.contains_key(service.get_name()) {
-            info!("Service {} is already running", service.get_name());
-            return Ok(());
-        }
-
-        // Get service-specific rootfs path
-        let service_rootfs = self.services_rootfs_dir.join(service.get_name());
-
-        // If service rootfs doesn't exist, try to create it from reference
-        if !service_rootfs.exists() {
-            info!(
-                "Service rootfs not found at {}, attempting to create from reference",
-                service_rootfs.display()
-            );
-
-            // Get base image name from service config
-            let base_image = service.get_base().ok_or_else(|| {
-                MonocoreError::ConfigValidation(format!(
-                    "Service {} has no base image specified",
-                    service.get_name()
-                ))
-            })?;
-
-            // Construct path to reference rootfs
-            let reference_rootfs = self
-                .services_rootfs_dir
-                .parent() // Go up from service dir
-                .ok_or_else(|| {
-                    MonocoreError::PathNotFound(
-                        "Invalid services rootfs path - no parent directory found".to_string(),
-                    )
-                })?
-                .join(REFERENCE_SUBDIR)
-                .join(crate::utils::parse_image_ref(base_image)?.2) // Convert repo:tag to repo__tag
-                .join(MERGED_SUBDIR);
-
-            if !reference_rootfs.exists() {
-                return Err(MonocoreError::RootfsNotFound(format!(
-                    "Reference rootfs not found at {}",
-                    reference_rootfs.display()
-                )));
-            }
-
-            // Create parent directories
-            fs::create_dir_all(service_rootfs.parent().unwrap()).await?;
-
-            // Copy reference rootfs to service rootfs
-            info!(
-                "Copying reference rootfs from {} to {}",
-                reference_rootfs.display(),
-                service_rootfs.display()
-            );
-
-            rootfs::copy(&reference_rootfs, &service_rootfs, false).await?;
-        }
-
-        // Get group and prepare configuration data
-        let group = self.config.get_group_for_service(service)?;
-        let group_name = group.get_name().to_string();
-
-        // Serialize configuration before IP assignment
-        let service_json = serde_json::to_string(service)?;
-        let group_json = serde_json::to_string(&group)?;
-
-        // Assign IP address to the group
-        let group_ip = self.assign_group_ip(&group_name)?;
-        let group_ip_json = serde_json::to_string(&group_ip)?;
-
-        // Start the supervisor process with service-specific rootfs
-        let child = Command::new(&self.supervisor_exe_path)
-            .arg("--run-supervisor")
-            .args([
-                &service_json,
-                &group_json,
-                &group_ip_json,
-                service_rootfs.to_str().unwrap(),
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-
-        let pid = child
-            .id()
-            .ok_or_else(|| MonocoreError::ProcessIdNotFound(service.get_name().to_string()))?;
-
-        self.running_services
-            .insert(service.get_name().to_string(), pid);
-
-        info!(
-            "Started supervisor for service {} with PID {}",
-            service.get_name(),
-            pid
-        );
-
-        // Spawn tasks to handle stdout and stderr
-        let service_name = service.get_name().to_string();
-        self.spawn_output_handler(child, service_name);
-
-        Ok(())
-    }
-
-    /// Sets up asynchronous handlers for process output streams, capturing stdout and stderr
-    /// from the supervised process and logging them appropriately.
-    fn spawn_output_handler(&self, mut child: Child, service_name: String) {
-        // Handle stdout
-        match child.stdout.take() {
-            Some(stdout) => {
-                let stdout_service_name = service_name.clone();
-                tokio::spawn(async move {
-                    let mut reader = BufReader::new(stdout).lines();
-                    while let Ok(Some(line)) = reader.next_line().await {
-                        info!("[{}/stdout] {}", stdout_service_name, line);
-                    }
-                });
-            }
-            None => {
-                warn!(
-                    "Failed to capture stdout for supervisor of service {}",
-                    service_name
-                );
-            }
-        }
-
-        // Handle stderr
-        match child.stderr.take() {
-            Some(stderr) => {
-                let stderr_service_name = service_name.clone();
-                tokio::spawn(async move {
-                    let mut reader = BufReader::new(stderr).lines();
-                    while let Ok(Some(line)) = reader.next_line().await {
-                        error!("[{}/stderr] {}", stderr_service_name, line);
-                    }
-                });
-            }
-            None => {
-                warn!(
-                    "Failed to capture stderr for supervisor of service {}",
-                    service_name
-                );
-            }
-        }
-
-        // Wait for the child process
-        tokio::spawn(async move {
-            match child.wait().await {
-                Ok(status) => {
-                    info!(
-                        "Service supervisor for {} exited with status: {}",
-                        service_name, status
-                    );
-                }
-                Err(e) => {
-                    error!("Failed to wait for service {}: {}", service_name, e);
-                }
-            }
-        });
-    }
-
-    /// Sends a termination signal to a service process identified by its PID.
-    async fn stop_service(&self, pid: u32) -> MonocoreResult<()> {
-        // Send SIGTERM only once
-        Command::new("kill")
-            .arg("-TERM")
-            .arg(pid.to_string())
-            .output()
-            .await
-            .map_err(|e| MonocoreError::ProcessKillError(e.to_string()))?;
-
-        Ok(())
-    }
-
-    /// Performs cleanup of old log files based on the configured maximum age. Removes
-    /// files that exceed the age threshold and logs the cleanup activity.
-    pub async fn cleanup_old_logs(&self) -> MonocoreResult<()> {
-        // Ensure log directory exists before attempting cleanup
-        if !fs::try_exists(&*MONOCORE_LOG_DIR).await? {
-            fs::create_dir_all(&*MONOCORE_LOG_DIR).await?;
-            return Ok(());
-        }
-
-        let now = SystemTime::now();
-        let mut cleaned_files = 0;
-
-        let mut entries = fs::read_dir(&*MONOCORE_LOG_DIR).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            if self
-                .should_delete_log(&entry, now, self.log_retention_policy.max_age)
-                .await?
-            {
-                if let Err(e) = fs::remove_file(entry.path()).await {
-                    warn!(
-                        "Failed to remove old log file {}: {}",
-                        entry.path().display(),
-                        e
-                    );
-                } else {
-                    cleaned_files += 1;
-                }
-            }
-        }
-
-        if cleaned_files > 0 {
-            info!("Cleaned up {} old log files", cleaned_files);
-        }
-
-        Ok(())
-    }
-
-    /// Evaluates whether a specific log file should be deleted based on its age and
-    /// file extension. Only processes files with .log or .log.old extensions.
-    async fn should_delete_log(
-        &self,
-        entry: &DirEntry,
-        now: SystemTime,
-        max_age: Duration,
-    ) -> MonocoreResult<bool> {
-        // Only process .log and .log.old files
-        let path = entry.path();
-        let is_log = path
-            .extension()
-            .map_or(false, |ext| ext == "log" || ext == "old");
-
-        if !is_log {
-            return Ok(false);
-        }
-
-        let metadata = entry.metadata().await?;
-        let modified = metadata.modified()?;
-
-        // Calculate file age
-        let age = now
-            .duration_since(modified)
-            .unwrap_or_else(|_| Duration::from_secs(0));
-
-        Ok(age > max_age)
-    }
-
     /// Creates a new Orchestrator instance from existing state files with custom log retention policy.
     /// This allows reconstructing the orchestrator's state from running services.
     ///
     /// ## Arguments
-    /// * `rootfs_path` - Path to the root filesystem
+    /// * `home_dir` - Path to the directory containing rootfs directories and service configuration files
     /// * `supervisor_exe_path` - Path to the supervisor executable
     /// * `log_retention_policy` - Configuration for log file retention and cleanup
     ///
@@ -596,7 +138,7 @@ impl Orchestrator {
     /// # }
     /// ```
     pub async fn load_with_log_retention_policy(
-        services_rootfs_dir: impl AsRef<Path>,
+        home_dir: impl AsRef<Path>,
         supervisor_exe_path: impl AsRef<Path>,
         log_retention_policy: LogRetentionPolicy,
     ) -> MonocoreResult<Self> {
@@ -627,7 +169,7 @@ impl Orchestrator {
 
         Ok(Self {
             config,
-            services_rootfs_dir: services_rootfs_dir.as_ref().to_path_buf(),
+            home_dir: home_dir.as_ref().to_path_buf(),
             supervisor_exe_path,
             running_services,
             log_retention_policy,
@@ -641,7 +183,7 @@ impl Orchestrator {
     /// This is a convenience method that uses the default log retention policy (7 days, auto cleanup enabled).
     ///
     /// ## Arguments
-    /// * `rootfs_path` - Path to the root filesystem
+    /// * `home_dir` - Path to the directory containing rootfs directories and service configuration files
     /// * `supervisor_exe_path` - Path to the supervisor executable
     ///
     /// ## Returns
@@ -660,118 +202,98 @@ impl Orchestrator {
     /// # }
     /// ```
     pub async fn load(
-        services_rootfs_dir: impl AsRef<Path>,
+        home_dir: impl AsRef<Path>,
         supervisor_exe_path: impl AsRef<Path>,
     ) -> MonocoreResult<Self> {
         Self::load_with_log_retention_policy(
-            services_rootfs_dir,
+            home_dir,
             supervisor_exe_path,
             LogRetentionPolicy::default(),
         )
         .await
     }
 
-    /// Assigns an IP address to a group from the 127.0.0.x range.
-    /// Returns the existing IP if the group already has one assigned.
-    ///
-    /// The IP assignment follows these rules:
-    /// - Uses addresses in the range 127.0.0.2 to 127.0.0.254
-    /// - Skips 127.0.0.0, 127.0.0.1, and 127.0.0.255
-    /// - Reuses IPs from terminated groups
-    /// - Maintains consistent IP assignment for a group
-    fn assign_group_ip(&mut self, group_name: &str) -> MonocoreResult<Option<Ipv4Addr>> {
-        // Return existing IP if already assigned
-        if let Some(ip) = self.assigned_ips.get(group_name) {
-            return Ok(Some(*ip));
-        }
-
-        // Find first available last octet (2-254, skipping 0, 1, and 255)
-        let last_octet = match (2..=254).find(|&n| !self.used_ips.contains(&n)) {
-            Some(n) => n,
-            None => return Ok(None), // No IPs available
-        };
-
-        let ip = Ipv4Addr::new(127, 0, 0, last_octet);
-        self.used_ips.insert(last_octet);
-        self.assigned_ips.insert(group_name.to_string(), ip);
-
-        Ok(Some(ip))
-    }
-
-    /// Releases an IP address assigned to a group, making it available for reuse.
-    /// This should be called when a group no longer has any running services.
-    fn release_group_ip(&mut self, group_name: &str) {
-        if let Some(ip) = self.assigned_ips.remove(group_name) {
-            self.used_ips.remove(&ip.octets()[3]);
-        }
-    }
-
-    /// Gets a reference to the map of running services and their supervisor PIDs
-    pub fn get_running_services(&self) -> &HashMap<String, u32> {
-        &self.running_services
-    }
-
     /// Gets a service from the current configuration by name
     pub fn get_service(&self, name: &str) -> Option<&Service> {
         self.config.get_service(name)
     }
-}
 
-impl LogRetentionPolicy {
-    /// Creates a new log retention policy with custom settings.
-    pub fn new(max_age: Duration, auto_cleanup: bool) -> Self {
-        Self {
-            max_age,
-            auto_cleanup,
+    /// Performs cleanup of old log files based on the configured maximum age. Removes
+    /// files that exceed the age threshold and logs the cleanup activity.
+    pub async fn cleanup_old_logs(&self) -> MonocoreResult<()> {
+        // Ensure log directory exists before attempting cleanup
+        if !fs::try_exists(&*MONOCORE_LOG_DIR).await? {
+            fs::create_dir_all(&*MONOCORE_LOG_DIR).await?;
+            return Ok(());
         }
+
+        let now = SystemTime::now();
+        let mut cleaned_files = 0;
+
+        let mut entries = fs::read_dir(&*MONOCORE_LOG_DIR).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if self
+                .should_delete_log(&entry, now, self.log_retention_policy.max_age)
+                .await?
+            {
+                if let Err(e) = fs::remove_file(entry.path()).await {
+                    tracing::warn!(
+                        "Failed to remove old log file {}: {}",
+                        entry.path().display(),
+                        e
+                    );
+                } else {
+                    cleaned_files += 1;
+                }
+            }
+        }
+
+        if cleaned_files > 0 {
+            tracing::info!("Cleaned up {} old log files", cleaned_files);
+        }
+
+        Ok(())
     }
 
-    /// Creates a new policy that retains logs for the specified number of hours.
-    pub fn with_max_age_hours(hours: u64) -> Self {
-        Self {
-            max_age: Duration::from_secs(hours * 60 * 60),
-            auto_cleanup: true,
-        }
+    /// Sends a termination signal to a service process identified by its PID.
+    pub(super) async fn stop_service(&self, pid: u32) -> MonocoreResult<()> {
+        // Send SIGTERM only once
+        Command::new("kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .output()
+            .await
+            .map_err(|e| MonocoreError::ProcessKillError(e.to_string()))?;
+
+        Ok(())
     }
 
-    /// Creates a new policy that retains logs for the specified number of days.
-    pub fn with_max_age_days(days: u64) -> Self {
-        Self {
-            max_age: Duration::from_secs(days * 24 * 60 * 60),
-            auto_cleanup: true,
-        }
-    }
+    /// Evaluates whether a specific log file should be deleted based on its age and
+    /// file extension. Only processes files with .log or .log.old extensions.
+    pub(super) async fn should_delete_log(
+        &self,
+        entry: &DirEntry,
+        now: SystemTime,
+        max_age: Duration,
+    ) -> MonocoreResult<bool> {
+        // Only process .log and .log.old files
+        let path = entry.path();
+        let is_log = path
+            .extension()
+            .map_or(false, |ext| ext == "log" || ext == "old");
 
-    /// Creates a new policy that retains logs for the specified number of weeks.
-    pub fn with_max_age_weeks(weeks: u64) -> Self {
-        Self {
-            max_age: Duration::from_secs(weeks * 7 * 24 * 60 * 60),
-            auto_cleanup: true,
+        if !is_log {
+            return Ok(false);
         }
-    }
 
-    /// Creates a new policy that retains logs for the specified number of months.
-    /// Note: Uses a 30-day approximation for months.
-    pub fn with_max_age_months(months: u64) -> Self {
-        Self {
-            max_age: Duration::from_secs(months * 30 * 24 * 60 * 60),
-            auto_cleanup: true,
-        }
-    }
-}
+        let metadata = entry.metadata().await?;
+        let modified = metadata.modified()?;
 
-//--------------------------------------------------------------------------------------------------
-// Trait Implementations
-//--------------------------------------------------------------------------------------------------
+        // Calculate file age
+        let age = now
+            .duration_since(modified)
+            .unwrap_or_else(|_| Duration::from_secs(0));
 
-impl Default for LogRetentionPolicy {
-    /// Creates a default configuration that:
-    /// - Keeps logs for 7 days
-    /// - Enables automatic cleanup during service operations
-    fn default() -> Self {
-        Self {
-            max_age: DEFAULT_LOG_MAX_AGE,
-            auto_cleanup: true,
-        }
+        Ok(age > max_age)
     }
 }

--- a/monocore/lib/orchestration/remove.rs
+++ b/monocore/lib/orchestration/remove.rs
@@ -33,7 +33,10 @@ impl Orchestrator {
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut orchestrator = Orchestrator::new("/path/to/rootfs", "/path/to/supervisor").await?;
     ///
-    /// orchestrator.remove_services(&["service1", "service2"]).await?;
+    /// orchestrator.remove_services(&[
+    ///     "service1".to_string(),
+    ///     "service2".to_string()
+    /// ]).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/monocore/lib/orchestration/remove.rs
+++ b/monocore/lib/orchestration/remove.rs
@@ -1,0 +1,188 @@
+use crate::{
+    utils::{ROOTFS_SUBDIR, SERVICE_SUBDIR},
+    MonocoreError, MonocoreResult,
+};
+use serde::Deserialize;
+use tokio::fs;
+
+use super::Orchestrator;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ServiceConfig {
+    group: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Orchestrator {
+    /// Removes the rootfs and configuration files for specified services.
+    /// This only removes persistent files, not runtime state or logs.
+    ///
+    /// ## Arguments
+    /// * `service_names` - Names of services to remove
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use monocore::orchestration::Orchestrator;
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let mut orchestrator = Orchestrator::new("/path/to/rootfs", "/path/to/supervisor").await?;
+    ///
+    /// orchestrator.remove_services(&["service1", "service2"]).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn remove_services(&mut self, service_names: &[String]) -> MonocoreResult<()> {
+        if service_names.is_empty() {
+            tracing::info!("No services specified for removal");
+            return Ok(());
+        }
+
+        let service_dir = self.home_dir.join(SERVICE_SUBDIR);
+        if !service_dir.exists() {
+            return Ok(());
+        }
+
+        // Validate services exist and aren't running
+        let mut services_to_remove = Vec::new();
+        for name in service_names {
+            let service_path = service_dir.join(name);
+            if !service_path.exists() {
+                tracing::warn!("Service directory not found: {}", service_path.display());
+                continue;
+            }
+
+            if self.running_services.contains_key(name) {
+                return Err(MonocoreError::ServiceStillRunning(format!(
+                    "Cannot remove running service: {}",
+                    name
+                )));
+            }
+
+            services_to_remove.push(name);
+        }
+
+        for service_name in services_to_remove {
+            self.remove_service_files(service_name).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Removes all services belonging to the specified group.
+    /// This only removes persistent files, not runtime state or logs.
+    ///
+    /// ## Arguments
+    /// * `group_name` - Name of the group whose services should be removed
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use monocore::orchestration::Orchestrator;
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let mut orchestrator = Orchestrator::new("/path/to/rootfs", "/path/to/supervisor").await?;
+    ///
+    /// orchestrator.remove_group("mygroup").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn remove_group(&mut self, group_name: &str) -> MonocoreResult<()> {
+        let service_dir = self.home_dir.join(SERVICE_SUBDIR);
+        if !service_dir.exists() {
+            return Ok(());
+        }
+
+        let mut services_to_remove = Vec::new();
+        let mut entries = fs::read_dir(&service_dir).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            if !entry.file_type().await?.is_dir() {
+                continue;
+            }
+
+            let config_path = entry.path().join("service.json");
+            if !config_path.exists() {
+                continue;
+            }
+
+            // Read and parse service config to check group
+            let config_str = fs::read_to_string(&config_path).await.map_err(|e| {
+                MonocoreError::ConfigNotFound(format!(
+                    "Failed to read service config at {}: {}",
+                    config_path.display(),
+                    e
+                ))
+            })?;
+            let config: ServiceConfig = serde_json::from_str(&config_str).map_err(|e| {
+                MonocoreError::ConfigNotFound(format!(
+                    "Failed to parse service config at {}: {}",
+                    config_path.display(),
+                    e
+                ))
+            })?;
+
+            if config.group.as_deref() == Some(group_name) {
+                let service_name = entry.file_name().to_string_lossy().into_owned();
+
+                // Check if service is running
+                if self.running_services.contains_key(&service_name) {
+                    return Err(MonocoreError::ServiceStillRunning(format!(
+                        "Cannot remove running service: {}",
+                        service_name
+                    )));
+                }
+
+                services_to_remove.push(service_name);
+            }
+        }
+
+        if services_to_remove.is_empty() {
+            tracing::info!("No services found in group {}", group_name);
+            return Ok(());
+        }
+
+        for service_name in services_to_remove {
+            self.remove_service_files(&service_name).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Helper method to remove service files (rootfs and config)
+    async fn remove_service_files(&self, service_name: &str) -> MonocoreResult<()> {
+        // Remove service rootfs
+        let service_rootfs = self
+            .home_dir
+            .join(ROOTFS_SUBDIR)
+            .join(SERVICE_SUBDIR)
+            .join(service_name);
+        if service_rootfs.exists() {
+            fs::remove_dir_all(&service_rootfs).await.map_err(|e| {
+                MonocoreError::LayerHandling {
+                    source: e,
+                    layer: service_rootfs.display().to_string(),
+                }
+            })?;
+            tracing::info!("Removed service rootfs at {}", service_rootfs.display());
+        }
+
+        // Remove service configuration directory
+        let service_config_dir = self.home_dir.join(SERVICE_SUBDIR).join(service_name);
+        if service_config_dir.exists() {
+            fs::remove_dir_all(&service_config_dir).await.map_err(|e| {
+                MonocoreError::ConfigNotFound(format!(
+                    "Failed to remove service config at {}: {}",
+                    service_config_dir.display(),
+                    e
+                ))
+            })?;
+            tracing::info!("Removed service config at {}", service_config_dir.display());
+        }
+
+        Ok(())
+    }
+}

--- a/monocore/lib/orchestration/status.rs
+++ b/monocore/lib/orchestration/status.rs
@@ -1,0 +1,69 @@
+use tokio::fs;
+
+use crate::{runtime::MicroVmState, utils::MONOCORE_STATE_DIR, MonocoreResult};
+
+use super::{utils, Orchestrator, ServiceStatus};
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Orchestrator {
+    /// Retrieves the current status of all services, including their process IDs and state
+    /// information. Also identifies and cleans up stale state files for processes that are
+    /// no longer running.
+    pub async fn status(&self) -> MonocoreResult<Vec<ServiceStatus>> {
+        let mut statuses = Vec::new();
+        let mut stale_files = Vec::new();
+
+        // Ensure directory exists before reading
+        if !fs::try_exists(&*MONOCORE_STATE_DIR).await? {
+            fs::create_dir_all(&*MONOCORE_STATE_DIR).await?;
+            return Ok(statuses);
+        }
+
+        // Read all state files from the state directory
+        let mut dir = fs::read_dir(&*MONOCORE_STATE_DIR).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            let path = entry.path();
+            if path.is_file() && path.extension().map_or(false, |ext| ext == "json") {
+                match fs::read_to_string(&path).await {
+                    Ok(contents) => match serde_json::from_str::<MicroVmState>(&contents) {
+                        Ok(state) => {
+                            // Check if the process is still running
+                            if let Some(pid) = state.get_pid() {
+                                if !utils::is_process_running(*pid).await {
+                                    stale_files.push(path);
+                                    continue;
+                                }
+                            }
+
+                            statuses.push(ServiceStatus {
+                                name: state.get_service().get_name().to_string(),
+                                pid: *state.get_pid(),
+                                state,
+                            });
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to parse state file {:?}: {}", path, e);
+                            stale_files.push(path);
+                        }
+                    },
+                    Err(e) => {
+                        tracing::error!("Failed to read state file {:?}: {}", path, e);
+                        stale_files.push(path);
+                    }
+                }
+            }
+        }
+
+        // Clean up stale files
+        for path in stale_files {
+            if let Err(e) = fs::remove_file(&path).await {
+                tracing::warn!("Failed to remove stale state file {:?}: {}", path, e);
+            }
+        }
+
+        Ok(statuses)
+    }
+}

--- a/monocore/lib/orchestration/up.rs
+++ b/monocore/lib/orchestration/up.rs
@@ -1,0 +1,350 @@
+use super::Orchestrator;
+use crate::{
+    config::{Monocore, Service},
+    oci::rootfs,
+    utils::{
+        MERGED_SUBDIR, OCI_REPO_SUBDIR, OCI_SUBDIR, REFERENCE_SUBDIR, ROOTFS_SUBDIR, SERVICE_SUBDIR,
+    },
+    MonocoreError, MonocoreResult,
+};
+use std::{collections::HashSet, net::Ipv4Addr, process::Stdio};
+use tokio::{
+    fs,
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, Command},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Orchestrator {
+    /// Starts or updates services according to the provided configuration.
+    /// Merges the new config with existing config and starts/restarts changed services.
+    pub async fn up(&mut self, new_config: Monocore) -> MonocoreResult<()> {
+        if self.log_retention_policy.auto_cleanup {
+            if let Err(e) = self.cleanup_old_logs().await {
+                tracing::warn!("Failed to clean up old logs during startup: {}", e);
+            }
+        }
+
+        // Clone current config to avoid borrowing issues
+        let current_config = self.config.clone();
+
+        // Get the services that changed or were added
+        let changed_services: HashSet<_> = current_config
+            .get_changed_services(&new_config)
+            .into_iter()
+            .map(|s| s.get_name().to_string())
+            .collect();
+
+        // Merge the configurations
+        self.config = current_config.merge(&new_config)?;
+
+        // Get ordered list of changed services based on dependencies
+        let ordered_services: Vec<_> = self
+            .config
+            .get_ordered_services()
+            .into_iter()
+            .filter(|s| changed_services.contains(s.get_name()))
+            .collect();
+
+        // Clone the ordered services to avoid borrow issues
+        let ordered_services: Vec<_> = ordered_services.into_iter().cloned().collect();
+
+        // Start/restart changed services in dependency order
+        for service in ordered_services {
+            // Stop the service if it's running
+            if let Some(pid) = self.running_services.get(service.get_name()) {
+                let pid = *pid; // Copy the pid to avoid borrow issues
+                self.stop_service(pid).await?;
+                self.running_services.remove(service.get_name());
+            }
+
+            // Start the service with new configuration
+            self.start_service(&service).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Starts a single service by spawning a supervisor process.
+    pub(super) async fn start_service(&mut self, service: &Service) -> MonocoreResult<()> {
+        if self.running_services.contains_key(service.get_name()) {
+            tracing::info!("Service {} is already running", service.get_name());
+            return Ok(());
+        }
+
+        // Get service-specific rootfs path
+        let service_rootfs = self
+            .home_dir
+            .join(ROOTFS_SUBDIR)
+            .join(SERVICE_SUBDIR)
+            .join(service.get_name());
+
+        // Get group and prepare configuration data
+        let group = self.config.get_group_for_service(service)?;
+        let group_name = group.get_name().to_string();
+
+        // Serialize configuration before IP assignment
+        let service_json = serde_json::to_string(service)?;
+        let group_json = serde_json::to_string(&group)?;
+
+        // Create service directory and store service details
+        self.store_service_details(service.get_name(), &service_json, &group_json)
+            .await?;
+
+        // If service rootfs doesn't exist, try to create it
+        if !service_rootfs.exists() {
+            tracing::info!(
+                "Service rootfs not found at {}, attempting to create",
+                service_rootfs.display()
+            );
+
+            // Get base image name from service config
+            let base_image = service.get_base().ok_or_else(|| {
+                MonocoreError::ConfigValidation(format!(
+                    "Service {} has no base image specified",
+                    service.get_name()
+                ))
+            })?;
+
+            // Parse image reference
+            let (_, _, repo_tag) = crate::utils::parse_image_ref(base_image)?;
+
+            // Construct paths
+            let reference_rootfs = self
+                .home_dir
+                .join(ROOTFS_SUBDIR)
+                .join(REFERENCE_SUBDIR)
+                .join(&repo_tag)
+                .join(MERGED_SUBDIR);
+
+            // First try using existing reference rootfs
+            if reference_rootfs.exists() {
+                tracing::info!(
+                    "Using existing reference rootfs from {}",
+                    reference_rootfs.display()
+                );
+                rootfs::copy(&reference_rootfs, &service_rootfs, false).await?;
+            } else {
+                // Check if image layers exist and try merging
+                let repo_dir = self
+                    .home_dir
+                    .join(OCI_SUBDIR)
+                    .join(OCI_REPO_SUBDIR)
+                    .join(&repo_tag);
+
+                if repo_dir.exists() {
+                    tracing::info!(
+                        "Reference rootfs not found but image layers exist, attempting merge for {}",
+                        base_image
+                    );
+
+                    // Create parent directories
+                    fs::create_dir_all(reference_rootfs.parent().unwrap()).await?;
+
+                    // Merge layers into reference rootfs
+                    rootfs::merge(
+                        &self.home_dir.join(OCI_SUBDIR),
+                        &reference_rootfs.parent().unwrap(),
+                        &repo_tag,
+                    )
+                    .await?;
+
+                    // Copy merged rootfs to service rootfs
+                    rootfs::copy(&reference_rootfs, &service_rootfs, false).await?;
+                } else {
+                    // Need to pull the image first
+                    tracing::info!(
+                        "Image layers not found for {}, attempting to pull image",
+                        base_image
+                    );
+
+                    crate::utils::pull_docker_image(&self.home_dir.join(OCI_SUBDIR), base_image)
+                        .await?;
+
+                    // Create reference rootfs from pulled image
+                    fs::create_dir_all(reference_rootfs.parent().unwrap()).await?;
+                    rootfs::merge(
+                        &self.home_dir.join(OCI_SUBDIR),
+                        &reference_rootfs.parent().unwrap(),
+                        &repo_tag,
+                    )
+                    .await?;
+
+                    // Copy to service rootfs
+                    rootfs::copy(&reference_rootfs, &service_rootfs, false).await?;
+                }
+            }
+        }
+
+        // Assign IP address to the group
+        let group_ip = self.assign_group_ip(&group_name)?;
+        let group_ip_json = serde_json::to_string(&group_ip)?;
+
+        // Start the supervisor process with service-specific rootfs
+        let child = Command::new(&self.supervisor_exe_path)
+            .arg("--run-supervisor")
+            .args([
+                &service_json,
+                &group_json,
+                &group_ip_json,
+                service_rootfs.to_str().unwrap(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| MonocoreError::ProcessIdNotFound(service.get_name().to_string()))?;
+
+        self.running_services
+            .insert(service.get_name().to_string(), pid);
+
+        tracing::info!(
+            "Started supervisor for service {} with PID {}",
+            service.get_name(),
+            pid
+        );
+
+        // Spawn tasks to handle stdout and stderr
+        let service_name = service.get_name().to_string();
+        self.spawn_output_handler(child, service_name);
+
+        Ok(())
+    }
+
+    /// Sets up asynchronous handlers for process output streams, capturing stdout and stderr
+    /// from the supervised process and logging them appropriately.
+    fn spawn_output_handler(&self, mut child: Child, service_name: String) {
+        // Handle stdout
+        match child.stdout.take() {
+            Some(stdout) => {
+                let stdout_service_name = service_name.clone();
+                tokio::spawn(async move {
+                    let mut reader = BufReader::new(stdout).lines();
+                    while let Ok(Some(line)) = reader.next_line().await {
+                        tracing::info!("[{}/stdout] {}", stdout_service_name, line);
+                    }
+                });
+            }
+            None => {
+                tracing::warn!(
+                    "Failed to capture stdout for supervisor of service {}",
+                    service_name
+                );
+            }
+        }
+
+        // Handle stderr
+        match child.stderr.take() {
+            Some(stderr) => {
+                let stderr_service_name = service_name.clone();
+                tokio::spawn(async move {
+                    let mut reader = BufReader::new(stderr).lines();
+                    while let Ok(Some(line)) = reader.next_line().await {
+                        tracing::error!("[{}/stderr] {}", stderr_service_name, line);
+                    }
+                });
+            }
+            None => {
+                tracing::warn!(
+                    "Failed to capture stderr for supervisor of service {}",
+                    service_name
+                );
+            }
+        }
+
+        // Wait for the child process
+        tokio::spawn(async move {
+            match child.wait().await {
+                Ok(status) => {
+                    tracing::info!(
+                        "Service supervisor for {} exited with status: {}",
+                        service_name,
+                        status
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("Failed to wait for service {}: {}", service_name, e);
+                }
+            }
+        });
+    }
+
+    /// Assigns an IP address to a group from the 127.0.0.x range.
+    /// Returns the existing IP if the group already has one assigned.
+    ///
+    /// The IP assignment follows these rules:
+    /// - Uses addresses in the range 127.0.0.2 to 127.0.0.254
+    /// - Skips 127.0.0.0, 127.0.0.1, and 127.0.0.255
+    /// - Reuses IPs from terminated groups
+    /// - Maintains consistent IP assignment for a group
+    pub(super) fn assign_group_ip(&mut self, group_name: &str) -> MonocoreResult<Option<Ipv4Addr>> {
+        // Return existing IP if already assigned
+        if let Some(ip) = self.assigned_ips.get(group_name) {
+            return Ok(Some(*ip));
+        }
+
+        // Find first available last octet (2-254, skipping 0, 1, and 255)
+        let last_octet = match (2..=254).find(|&n| !self.used_ips.contains(&n)) {
+            Some(n) => n,
+            None => return Ok(None), // No IPs available
+        };
+
+        let ip = Ipv4Addr::new(127, 0, 0, last_octet);
+        self.used_ips.insert(last_octet);
+        self.assigned_ips.insert(group_name.to_string(), ip);
+
+        Ok(Some(ip))
+    }
+
+    /// Stores service and group configuration files in the service directory.
+    /// Only creates the files if they don't already exist.
+    async fn store_service_details(
+        &self,
+        service_name: &str,
+        service_json: &str,
+        group_json: &str,
+    ) -> MonocoreResult<()> {
+        // Construct service directory path
+        let service_dir = self.home_dir.join(SERVICE_SUBDIR).join(service_name);
+
+        // Create service directory if it doesn't exist
+        fs::create_dir_all(&service_dir).await?;
+
+        // Paths to config files
+        let service_json_path = service_dir.join("service.json");
+        let group_json_path = service_dir.join("group.json");
+
+        // Only write service.json if it doesn't exist
+        if !service_json_path.exists() {
+            fs::write(&service_json_path, service_json).await?;
+            tracing::debug!(
+                "Created service.json for {} at {}",
+                service_name,
+                service_json_path.display()
+            );
+        }
+
+        // Only write group.json if it doesn't exist
+        if !group_json_path.exists() {
+            fs::write(&group_json_path, group_json).await?;
+            tracing::debug!(
+                "Created group.json for {} at {}",
+                service_name,
+                group_json_path.display()
+            );
+        }
+
+        tracing::debug!(
+            "Service details for {} stored in {}",
+            service_name,
+            service_dir.display()
+        );
+
+        Ok(())
+    }
+}

--- a/monocore/lib/utils/oci.rs
+++ b/monocore/lib/utils/oci.rs
@@ -49,7 +49,7 @@ pub async fn pull_docker_image(oci_dir: impl AsRef<Path>, image_ref: &str) -> Mo
     }
 
     let registry = DockerRegistry::with_oci_dir(oci_dir.into());
-    registry.pull_image(repository, Some(tag)).await
+    registry.pull_image(&repository, Some(&tag)).await
 }
 
 /// Merges OCI image layers into a single rootfs directory.

--- a/monocore/lib/utils/path.rs
+++ b/monocore/lib/utils/path.rs
@@ -55,6 +55,9 @@ lazy_static::lazy_static! {
     /// The path to the monocore rootfs directory
     pub static ref MONOCORE_ROOTFS_DIR: PathBuf = monocore_home_path().join(ROOTFS_SUBDIR);
 
+    /// The path to the monocore service directory
+    pub static ref MONOCORE_SERVICE_DIR: PathBuf = monocore_home_path().join(SERVICE_SUBDIR);
+
     /// The path to the monocore state directory (e.g. for storing service state files)
     pub static ref MONOCORE_STATE_DIR: PathBuf = monocore_home_path().join(STATE_SUBDIR);
 


### PR DESCRIPTION
## Overview
This PR refactors the orchestrator module to improve code organization and adds new service management features, including a CLI command for removing services. The changes make the codebase more maintainable and provide better tools for managing service lifecycles.

## Key Changes

### Code Organization
- Split `orchestrator.rs` into focused modules:
  - `up.rs`: Service startup logic
  - `down.rs`: Service shutdown handling
  - `status.rs`: Status monitoring
  - `remove.rs`: Service removal
  - `log_policy.rs`: Log retention

### New Features
- **Service Configuration Storage**
  - Store service configs in `~/.monocore/service/[name]/`
  - Persist service.json and group.json for each service
  - Improve service state recovery

- **CLI Remove Command**
  ```bash
  # Remove specific services
  monocore remove service1 service2

  # Remove all services in a group
  monocore remove -g mygroup
  ```
  - Validates services aren't running before removal
  - Cleans up rootfs and config files
  - Requires either services list or group flag

### Directory Structure
- Consolidated state under `~/.monocore/`:
  ```
  ~/.monocore/
  ├── oci/
  ├── rootfs/
  │   ├── reference/
  │   └── service/
  ├── service/
  ├── run/
  └── log/
  ```

### Documentation
- Added directory structure diagram
- Updated CLI usage examples
- Added development tips
- Improved error messages

### Image Handling
- Auto-qualify unqualified image names with "library/"
- Improved registry URL parsing
- Made `parse_image_ref` return owned strings

## Screenshots
N/A - CLI tool changes only