### PR TITLE
feat: Add REST API server mode

### DIFF
--- a/monocore/README.md
+++ b/monocore/README.md
@@ -96,9 +96,51 @@ monocore down
 monocore remove -g main
 ```
 
+3. Run in server mode:
+```bash
+# Start the REST API server (default port: 3000)
+monocore serve --port 3000
+
+# Or use the default port
+monocore serve
+```
+
 For more CLI options:
 ```bash
 monocore --help
+```
+
+### REST API
+
+When running in server mode, monocore provides a REST API for managing services:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/up`    | POST   | Start services defined in config |
+| `/down`  | POST   | Stop running services |
+| `/status`| GET    | Get status of all services |
+| `/remove`| POST   | Remove service files |
+
+Example API usage:
+
+```bash
+# Start services
+curl -X POST http://localhost:3000/up \
+  -H "Content-Type: application/json" \
+  -d @monocore.toml
+
+# Get service status
+curl http://localhost:3000/status
+
+# Stop services in a group
+curl -X POST http://localhost:3000/down \
+  -H "Content-Type: application/json" \
+  -d '{"group": "main"}'
+
+# Remove services
+curl -X POST http://localhost:3000/remove \
+  -H "Content-Type: application/json" \
+  -d '{"services": ["counter", "date-service"]}'
 ```
 
 ## Features

--- a/monocore/lib/cli/args.rs
+++ b/monocore/lib/cli/args.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use tracing::Level;
 
-use crate::utils::DEFAULT_MONOCORE_HOME;
+use crate::{config::DEFAULT_SERVER_PORT, utils::DEFAULT_MONOCORE_HOME};
 
 use super::styles;
 
@@ -83,6 +83,17 @@ pub enum MonocoreSubcommand {
         /// Remove all services in this group
         #[arg(short, long)]
         group: Option<String>,
+
+        /// Home directory for monocore state (default: ~/.monocore)
+        #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]
+        home_dir: PathBuf,
+    },
+
+    /// Start monocore in server mode
+    Serve {
+        /// Port to listen on
+        #[arg(short, long, default_value_t = DEFAULT_SERVER_PORT)]
+        port: u16,
 
         /// Home directory for monocore state (default: ~/.monocore)
         #[arg(long, default_value = DEFAULT_MONOCORE_HOME.as_os_str())]

--- a/monocore/lib/config/defaults.rs
+++ b/monocore/lib/config/defaults.rs
@@ -12,3 +12,6 @@ pub const DEFAULT_RAM_MIB: u32 = 1024;
 
 /// Default maximum age for log files (7 days)
 pub const DEFAULT_LOG_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Default port for the HTTP server
+pub const DEFAULT_SERVER_PORT: u16 = 3000;

--- a/monocore/lib/lib.rs
+++ b/monocore/lib/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod oci;
 pub mod orchestration;
 pub mod runtime;
+pub mod server;
 pub mod utils;
 pub mod vm;
 

--- a/monocore/lib/server/handlers.rs
+++ b/monocore/lib/server/handlers.rs
@@ -1,0 +1,222 @@
+//! HTTP request handlers for the REST API.
+//!
+//! This module implements the handlers for each API endpoint. The handlers
+//! coordinate with the Orchestrator to perform the requested operations.
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+
+use super::{
+    state::ServerState,
+    types::{
+        DownRequest, DownResponse, ErrorResponse, RemoveRequest, RemoveResponse, ServiceMetrics,
+        ServiceStatus, StatusResponse, UpRequest, UpResponse,
+    },
+};
+use crate::MonocoreResult;
+
+//-------------------------------------------------------------------------------------------------
+// Functions: Handlers
+//-------------------------------------------------------------------------------------------------
+
+/// Handler for the POST /up endpoint
+///
+/// Starts services according to the provided configuration
+pub async fn up_handler(
+    State(state): State<ServerState>,
+    Json(req): Json<UpRequest>,
+) -> impl IntoResponse {
+    match handle_up(state, req).await {
+        Ok(started) => (
+            StatusCode::OK,
+            Json(UpResponse {
+                started_services: started,
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for the POST /down endpoint
+///
+/// Stops running services, optionally filtered by group
+pub async fn down_handler(
+    State(state): State<ServerState>,
+    Json(req): Json<DownRequest>,
+) -> impl IntoResponse {
+    match handle_down(state, req).await {
+        Ok(stopped) => (
+            StatusCode::OK,
+            Json(DownResponse {
+                stopped_services: stopped,
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for the GET /status endpoint
+///
+/// Returns status information for all running services
+pub async fn status_handler(State(state): State<ServerState>) -> impl IntoResponse {
+    match handle_status(state).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for the POST /remove endpoint
+///
+/// Removes service files for specified services or group
+pub async fn remove_handler(
+    State(state): State<ServerState>,
+    Json(req): Json<RemoveRequest>,
+) -> impl IntoResponse {
+    match handle_remove(state, req).await {
+        Ok(removed) => (
+            StatusCode::OK,
+            Json(RemoveResponse {
+                removed_services: removed,
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Implementation of the up operation
+async fn handle_up(state: ServerState, req: UpRequest) -> MonocoreResult<Vec<String>> {
+    let mut orchestrator = state.orchestrator().write().await;
+
+    // Get list of running services before startup
+    let running_before: Vec<String> = orchestrator
+        .get_running_services()
+        .keys()
+        .cloned()
+        .collect();
+
+    // Start services
+    orchestrator.up(req.config).await?;
+
+    // Get list of running services after startup
+    let running_after: Vec<String> = orchestrator
+        .get_running_services()
+        .keys()
+        .cloned()
+        .collect();
+
+    // Return list of services that were newly started
+    Ok(running_after
+        .into_iter()
+        .filter(|s| !running_before.contains(s))
+        .collect())
+}
+
+/// Implementation of the down operation
+async fn handle_down(state: ServerState, req: DownRequest) -> MonocoreResult<Vec<String>> {
+    let mut orchestrator = state.orchestrator().write().await;
+
+    // Get list of running services before shutdown
+    let running_before: Vec<String> = orchestrator
+        .get_running_services()
+        .keys()
+        .cloned()
+        .collect();
+
+    // Stop services
+    orchestrator.down(req.group.as_deref()).await?;
+
+    // Get list of running services after shutdown
+    let running_after: Vec<String> = orchestrator
+        .get_running_services()
+        .keys()
+        .cloned()
+        .collect();
+
+    // Return list of services that were actually stopped
+    Ok(running_before
+        .into_iter()
+        .filter(|s| !running_after.contains(s))
+        .collect())
+}
+
+/// Implementation of the status operation
+async fn handle_status(state: ServerState) -> MonocoreResult<StatusResponse> {
+    let orchestrator = state.orchestrator().read().await;
+    let statuses = orchestrator.status().await?;
+
+    Ok(StatusResponse {
+        services: statuses
+            .into_iter()
+            .map(|s| ServiceStatus {
+                name: s.get_name().to_string(),
+                group: Some(s.get_state().get_group().get_name().to_string()),
+                status: format!("{:?}", s.get_state().get_status()),
+                pid: *s.get_pid(),
+                metrics: ServiceMetrics {
+                    cpu_usage: *s.get_state().get_metrics().get_cpu_usage() as f64,
+                    memory_usage: *s.get_state().get_metrics().get_memory_usage(),
+                },
+            })
+            .collect(),
+    })
+}
+
+/// Implementation of the remove operation
+async fn handle_remove(state: ServerState, req: RemoveRequest) -> MonocoreResult<Vec<String>> {
+    let mut orchestrator = state.orchestrator().write().await;
+    let services_before: Vec<String> = orchestrator
+        .status()
+        .await?
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+
+    match (req.services.is_empty(), req.group) {
+        (false, None) => orchestrator.remove_services(&req.services).await?,
+        (true, Some(group)) => orchestrator.remove_group(&group).await?,
+        _ => {
+            return Err(crate::MonocoreError::InvalidArgument(
+                "Must specify either services or group".to_string(),
+            ))
+        }
+    }
+
+    let services_after: Vec<String> = orchestrator
+        .status()
+        .await?
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+
+    // Return list of services that were actually removed
+    Ok(services_before
+        .into_iter()
+        .filter(|s| !services_after.contains(s))
+        .collect())
+}

--- a/monocore/lib/server/mod.rs
+++ b/monocore/lib/server/mod.rs
@@ -1,0 +1,25 @@
+//! Server module for monocore.
+//!
+//! This module implements a REST API server that provides HTTP endpoints for managing
+//! monocore services. The server is stateless and uses an Orchestrator instance for
+//! all state management.
+//!
+//! The server provides the following endpoints:
+//! - POST /up - Start services with provided configuration
+//! - POST /down - Stop running services
+//! - GET /status - Get status of all services
+//! - POST /remove - Remove service files
+
+mod handlers;
+mod routes;
+mod state;
+mod types;
+
+//--------------------------------------------------------------------------------------------------
+// Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use handlers::*;
+pub use routes::*;
+pub use state::*;
+pub use types::*;

--- a/monocore/lib/server/routes.rs
+++ b/monocore/lib/server/routes.rs
@@ -1,0 +1,30 @@
+//! Route definitions for the HTTP server.
+//!
+//! This module sets up the routing for the REST API endpoints.
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use super::{handlers, state::ServerState};
+
+//-------------------------------------------------------------------------------------------------
+// Functions
+//-------------------------------------------------------------------------------------------------
+
+/// Creates a new router with all API endpoints configured
+///
+/// ## Arguments
+/// * `state` - The shared server state
+///
+/// # Returns
+/// A configured Router instance
+pub fn create_router(state: ServerState) -> Router {
+    Router::new()
+        .route("/up", post(handlers::up_handler))
+        .route("/down", post(handlers::down_handler))
+        .route("/status", get(handlers::status_handler))
+        .route("/remove", post(handlers::remove_handler))
+        .with_state(state)
+}

--- a/monocore/lib/server/state.rs
+++ b/monocore/lib/server/state.rs
@@ -1,0 +1,56 @@
+//! Server state management.
+//!
+//! This module provides the ServerState type which manages shared state for the
+//! HTTP server, primarily the Orchestrator instance.
+
+use std::{path::PathBuf, sync::Arc};
+use tokio::sync::RwLock;
+
+use crate::orchestration::Orchestrator;
+
+//-------------------------------------------------------------------------------------------------
+// Types
+//-------------------------------------------------------------------------------------------------
+
+/// Shared server state containing the orchestrator
+///
+/// This type provides thread-safe access to the Orchestrator instance through
+/// an Arc<RwLock>. It is shared across all HTTP request handlers.
+#[derive(Clone)]
+pub struct ServerState {
+    /// The shared orchestrator instance
+    orchestrator: Arc<RwLock<Orchestrator>>,
+}
+
+impl ServerState {
+    /// Creates a new ServerState instance
+    ///
+    /// # Arguments
+    /// * `home_dir` - Home directory for monocore state
+    /// * `supervisor_path` - Path to the supervisor executable
+    ///
+    /// # Returns
+    /// A new ServerState instance wrapped in a Result
+    pub async fn new(home_dir: PathBuf, supervisor_path: PathBuf) -> crate::MonocoreResult<Self> {
+        // Try to load existing orchestrator state, fall back to creating new if loading fails
+        let orchestrator = match Orchestrator::load(&home_dir, &supervisor_path).await {
+            Ok(orchestrator) => {
+                tracing::info!("Loaded existing orchestrator state");
+                orchestrator
+            }
+            Err(e) => {
+                tracing::info!("Creating new orchestrator: {}", e);
+                Orchestrator::new(&home_dir, &supervisor_path).await?
+            }
+        };
+
+        Ok(Self {
+            orchestrator: Arc::new(RwLock::new(orchestrator)),
+        })
+    }
+
+    /// Gets a reference to the orchestrator lock
+    pub fn orchestrator(&self) -> &Arc<RwLock<Orchestrator>> {
+        &self.orchestrator
+    }
+}

--- a/monocore/lib/server/types.rs
+++ b/monocore/lib/server/types.rs
@@ -1,0 +1,95 @@
+//! Type definitions for the server module.
+//!
+//! This module contains request and response types used by the REST API endpoints.
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Monocore;
+
+//-------------------------------------------------------------------------------------------------
+// Types
+//-------------------------------------------------------------------------------------------------
+
+/// Request body for the /up endpoint
+#[derive(Debug, Deserialize)]
+pub struct UpRequest {
+    /// The monocore configuration to apply
+    pub config: Monocore,
+    /// Optional group name to only start services in that group
+    pub group: Option<String>,
+}
+
+/// Request body for the /down endpoint
+#[derive(Debug, Deserialize)]
+pub struct DownRequest {
+    /// Optional group name to only stop services in that group
+    pub group: Option<String>,
+}
+
+/// Request body for the /remove endpoint
+#[derive(Debug, Deserialize)]
+pub struct RemoveRequest {
+    /// List of service names to remove
+    pub services: Vec<String>,
+    /// Optional group name to remove all services in that group
+    pub group: Option<String>,
+}
+
+/// Response body for the /status endpoint
+#[derive(Debug, Serialize)]
+pub struct StatusResponse {
+    /// List of service statuses
+    pub services: Vec<ServiceStatus>,
+}
+
+/// Status information for a single service
+#[derive(Debug, Serialize)]
+pub struct ServiceStatus {
+    /// Name of the service
+    pub name: String,
+    /// Group the service belongs to
+    pub group: Option<String>,
+    /// Current status of the service
+    pub status: String,
+    /// Process ID of the service if running
+    pub pid: Option<u32>,
+    /// Resource usage metrics
+    pub metrics: ServiceMetrics,
+}
+
+/// Resource usage metrics for a service
+#[derive(Debug, Serialize)]
+pub struct ServiceMetrics {
+    /// CPU usage as a percentage
+    pub cpu_usage: f64,
+    /// Memory usage in bytes
+    pub memory_usage: u64,
+}
+
+/// Error response returned when an operation fails
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    /// Error message describing what went wrong
+    pub error: String,
+}
+
+/// Response body for the /up endpoint
+#[derive(Debug, Serialize)]
+pub struct UpResponse {
+    /// List of services that were started
+    pub started_services: Vec<String>,
+}
+
+/// Response body for the /down endpoint
+#[derive(Debug, Serialize)]
+pub struct DownResponse {
+    /// List of services that were stopped
+    pub stopped_services: Vec<String>,
+}
+
+/// Response body for the /remove endpoint
+#[derive(Debug, Serialize)]
+pub struct RemoveResponse {
+    /// List of services that were removed
+    pub removed_services: Vec<String>,
+}


### PR DESCRIPTION
## Overview

This PR adds a new server mode to monocore that exposes a REST API for managing services. The server provides endpoints for starting, stopping, checking status, and removing services.

## Key changes
- Added new `serve` subcommand to start monocore in server mode
- Implemented REST API endpoints:
  - POST /up - Start services defined in config
  - POST /down - Stop running services 
  - GET /status - Get status of all services
  - POST /remove - Remove service files
- Added server-related modules:
  - handlers.rs - Request handlers for each endpoint
  - routes.rs - API route definitions
  - state.rs - Server state management
  - types.rs - Request/response type definitions
- Updated README with API documentation and examples
- Added default server port (3000) configuration

The REST API allows monocore to be integrated with other tools and services while maintaining the same functionality as the CLI. All operations available through the CLI can now be performed via HTTP requests.

## Example usage

```bash
# Start services from config file
curl -X POST http://localhost:3000/up \
-H "Content-Type: application/json" \
-d @monocore.toml

# Start services in specific group
curl -X POST http://localhost:3000/up \
-H "Content-Type: application/json" \
-d '{"config": {...}, "group": "backend"}'

# Get status of all services
curl http://localhost:3000/status

# Stop all services in a group
curl -X POST http://localhost:3000/down \
-H "Content-Type: application/json" \
-d '{"group": "frontend"}'

# Stop all services
curl -X POST http://localhost:3000/down \
-H "Content-Type: application/json" \
-d '{}'

# Remove specific services
curl -X POST http://localhost:3000/remove \
-H "Content-Type: application/json" \
-d '{"services": ["web", "api"]}'

# Remove all services in a group
curl -X POST http://localhost:3000/remove \
-H "Content-Type: application/json" \
-d '{"group": "backend"}'
```