### PR TITLE
chore: simplify installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,10 @@ private
 .history
 .DS_Store
 
-# Build dirs
+# monocore
+monocore.toml
+ignore/
 build/
 monocore/build/
-
-# Helper files
-diff.txt
-commit-msg.md
-commit-msg.txt
-pr.md
-pr.txt
-
-# monocore.toml
-monocore.toml
+libkrunfw.*
+libkrun.*

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ install: build
 	install -m 755 $(BUILD_DIR)/monocore $(HOME_BIN)/monocore
 	install -m 755 $(BUILD_DIR)/monokrun $(HOME_BIN)/monokrun
 
+	# Create mc symlink
+	ln -sf $(HOME_BIN)/monocore $(HOME_BIN)/mc
+
 	# Install libraries and create symlinks
 	@if [ -n "$(LIBKRUNFW_FILE)" ]; then \
 		install -m 755 $(LIBKRUNFW_FILE) $(HOME_LIB)/; \

--- a/build_libkrun.sh
+++ b/build_libkrun.sh
@@ -17,7 +17,7 @@
 #   - make
 #   - Rust/Cargo (for libkrun)
 #   - Python (for libkrunfw)
-#   - On macOS: krunvm must be installed (brew install krunvm)
+#   - On macOS: krunvm must be installed (brew tap slp/krun && brew install krunvm)
 #
 # The script performs the following tasks:
 #   1. Creates build directory if needed
@@ -80,12 +80,13 @@ error() {
 # Store the original working directory
 ORIGINAL_DIR="$(pwd)"
 
+# Ensure PATH includes common binary locations
+export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+
 # Set up variables
 BUILD_DIR="$ORIGINAL_DIR/build"
 LIBKRUNFW_REPO="https://github.com/appcypher/libkrunfw.git"
 LIBKRUN_REPO="https://github.com/appcypher/libkrun.git"
-LIB_DIR="/usr/local/lib"
-LIB64_DIR="/usr/local/lib64"
 NO_CLEANUP=false
 FORCE_BUILD=false
 
@@ -109,10 +110,18 @@ OS_TYPE="$(uname -s)"
 
 # Check if krunvm is installed on macOS, if applicable
 if [ "$OS_TYPE" = "Darwin" ]; then
-  if ! command -v krunvm &> /dev/null; then
-    printf "${RED}krunvm command not found. Please install it using: brew install krunvm${RESET}\n"
+  if ! which krunvm >/dev/null 2>&1; then
+    printf "${RED}krunvm command not found. Please install it using: brew tap slp/krun && brew install krunvm${RESET}\n"
     exit 1
   fi
+fi
+
+# Check for patchelf on Linux
+if [ "$OS_TYPE" = "Linux" ]; then
+    if ! which patchelf >/dev/null 2>&1; then
+        error "patchelf command not found. Please install it using your package manager."
+        exit 1
+    fi
 fi
 
 # Function to handle cleanup
@@ -126,13 +135,13 @@ cleanup() {
 
   cd "$ORIGINAL_DIR" || { error "Failed to change back to original directory"; exit 1; }
 
-  sudo rm -rf "$BUILD_DIR"
+  rm -rf "$BUILD_DIR"
   if [ "$OS_TYPE" = "Darwin" ]; then
     warn "Deleting libkrunfw-builder VM..."
-    sudo krunvm delete libkrunfw-builder
+    krunvm delete libkrunfw-builder
 
     warn "Deleting libkrun-builder VM..."
-    sudo krunvm delete libkrun-builder
+    krunvm delete libkrun-builder
   fi
   info "Cleanup complete."
 }
@@ -150,27 +159,31 @@ check_success() {
 
 # Common function to check for existing installations
 check_existing_lib() {
-    if [ "$FORCE_BUILD" = true ]; then  # Check if force build is enabled
+    if [ "$FORCE_BUILD" = true ]; then
         info "Force build enabled. Skipping check for existing $1."
         return 0
     fi
 
     local lib_name="$1"
+
+    # Get ABI version from the appropriate Makefile
+    local abi_version=$(get_abi_version "$BUILD_DIR/$lib_name/Makefile")
+
     case "$OS_TYPE" in
         Linux)
-          lib_path="$LIB64_DIR/$lib_name.so"
-          ;;
+            lib_path="$BUILD_DIR/$lib_name.so.$abi_version"
+            ;;
         Darwin)
-          lib_path="$LIB_DIR/$lib_name.dylib"
-          ;;
+            lib_path="$BUILD_DIR/$lib_name.$abi_version.dylib"
+            ;;
         *)
-          error "Unsupported OS: $OS_TYPE"
-          exit 1
-          ;;
+            error "Unsupported OS: $OS_TYPE"
+            exit 1
+            ;;
     esac
 
     if [ -f "$lib_path" ]; then
-        info "$lib_name already exists in $lib_path. Skipping cloning, building, and installation."
+        info "$lib_name already exists in $lib_path. Skipping build."
         return 1
     fi
     return 0
@@ -205,79 +218,117 @@ clone_repo() {
   fi
 }
 
-# Function to create non-versioned library
-create_non_versioned_lib() {
-  local lib_name="$1"
-  local extension="$2"
-
-  local versioned_lib=$(ls "${lib_name}"*".${extension}"*"" 2>/dev/null | head -n 1)
-
-  if [ -n "$versioned_lib" ]; then
-    cp "$versioned_lib" "${lib_name}.${extension}"
-    check_success "Failed to create non-versioned ${lib_name}.${extension}"
-    info "Created non-versioned ${lib_name}.${extension}"
-  else
-    error "No ${lib_name}.*.${extension} file found"
-    exit 1
-  fi
+# Function to extract ABI version from Makefile
+get_abi_version() {
+    local makefile="$1"
+    local abi_version=$(grep "^ABI_VERSION.*=" "$makefile" | cut -d'=' -f2 | tr -d ' ')
+    if [ -z "$abi_version" ]; then
+        error "Could not determine ABI version from $makefile"
+        exit 1
+    fi
+    echo "$abi_version"
 }
 
-# Function to build and install a library
-build_and_install_lib() {
-  local lib_name="$1"
+# Function to extract FULL_VERSION from Makefile
+get_full_version() {
+    local makefile="$1"
+    local full_version=$(grep "^FULL_VERSION.*=" "$makefile" | cut -d'=' -f2 | tr -d ' ')
+    if [ -z "$full_version" ]; then
+        error "Could not determine FULL_VERSION from $makefile"
+        exit 1
+    fi
+    echo "$full_version"
+}
 
-  cd "$BUILD_DIR/$lib_name" || { error "Failed to change to $lib_name directory"; exit 1; }
+# Function to build and copy libkrunfw
+build_libkrunfw() {
+    cd "$BUILD_DIR/libkrunfw" || { error "Failed to change to libkrunfw directory"; exit 1; }
 
-  # Build the library
-  info "Building $lib_name..."
-  if [ "$lib_name" = "libkrunfw" ]; then
-    # Set PYTHONPATH to include the user's site-packages
+    local abi_version=$(get_abi_version "Makefile")
+    info "Detected libkrunfw ABI version: $abi_version"
+
+    info "Building libkrunfw..."
     export PYTHONPATH="$HOME/.local/lib/python3.*/site-packages:$PYTHONPATH"
 
-    # Build with PYTHONPATH
-    make PYTHONPATH="$PYTHONPATH"
-  else
-    # For libkrun
-    info "Setting LIBRARY_PATH for libkrunfw..."
-    export LIBRARY_PATH="$LIB64_DIR:$LIB_DIR:$LIBRARY_PATH"
+    case "$OS_TYPE" in
+        Darwin)
+            # On macOS, we need sudo to allow krunvm set xattr on the volume
+            sudo make PYTHONPATH="$PYTHONPATH"
+            ;;
+        *)
+            make PYTHONPATH="$PYTHONPATH"
+            ;;
+    esac
+    check_success "Failed to build libkrunfw"
 
-    # Ensure Rust and Cargo are in the PATH
+    # Copy the library to build directory and create symlink
+    info "Copying libkrunfw to build directory..."
+    cd "$BUILD_DIR" || { error "Failed to change to build directory"; exit 1; }
+    case "$OS_TYPE" in
+        Linux)
+            cp libkrunfw/libkrunfw.so.$abi_version.* "libkrunfw.so.$abi_version"
+            patchelf --set-rpath '$ORIGIN' "libkrunfw.so.$abi_version"
+            ln -sf "libkrunfw.so.$abi_version" "libkrunfw.so"
+            ;;
+        Darwin)
+            cp libkrunfw/libkrunfw.$abi_version.dylib "libkrunfw.$abi_version.dylib"
+            install_name_tool -id "@rpath/libkrunfw.$abi_version.dylib" "libkrunfw.$abi_version.dylib"
+            ln -sf "libkrunfw.$abi_version.dylib" "libkrunfw.dylib"
+            ;;
+        *)
+            error "Unsupported OS: $OS_TYPE"
+            exit 1
+            ;;
+    esac
+    check_success "Failed to copy libkrunfw"
+}
+
+# Function to build and copy libkrun
+build_libkrun() {
+    cd "$BUILD_DIR/libkrun" || { error "Failed to change to libkrun directory"; exit 1; }
+
+    local abi_version=$(get_abi_version "Makefile")
+    local full_version=$(get_full_version "Makefile")
+    info "Detected libkrun ABI version: $abi_version"
+    info "Detected libkrun FULL version: $full_version"
+
+    info "Building libkrun..."
+    # Update library path to use our build directory
+    export LIBRARY_PATH="$BUILD_DIR:$LIBRARY_PATH"
     export PATH="$HOME/.cargo/bin:$PATH"
 
-    # Build with PATH and LIBRARY_PATH
-    make LIBRARY_PATH="$LIBRARY_PATH" PATH="$PATH"
-  fi
-  check_success "Failed to build $lib_name"
-
-  # Install the library
-  info "Installing $lib_name..."
-  sudo make install
-  check_success "Failed to install $lib_name"
-
-  # On macOS, patch the dylib install name to point to its actual location
-  if [ "$OS_TYPE" = "Darwin" ]; then
-    info "Patching dylib install name for $lib_name..."
-    sudo install_name_tool -id "$LIB_DIR/${lib_name}.dylib" "$LIB_DIR/${lib_name}.dylib"
-    check_success "Failed to patch dylib install name for $lib_name"
-  fi
-
-  # Create non-versioned variant of libkrunfw.
-  # Needed for GH action CI builds.
-  if [ "$lib_name" = "libkrunfw" ]; then
-    info "Creating non-versioned variant of $lib_name..."
     case "$OS_TYPE" in
-      Linux)
-        create_non_versioned_lib "libkrunfw" "so"
-        ;;
-      Darwin)
-        create_non_versioned_lib "libkrunfw" "dylib"
-        ;;
-      *)
-        error "Unsupported OS: $OS_TYPE"
-        exit 1
-        ;;
+        Darwin)
+            sudo make LIBRARY_PATH="$LIBRARY_PATH" PATH="$PATH"
+            ;;
+        *)
+            make LIBRARY_PATH="$LIBRARY_PATH" PATH="$PATH"
+            ;;
     esac
-  fi
+    check_success "Failed to build libkrun"
+
+    # Copy and rename the library to build directory and create symlink
+    info "Copying libkrun to build directory..."
+    cd "$BUILD_DIR" || { error "Failed to change to build directory"; exit 1; }
+    case "$OS_TYPE" in
+        Linux)
+            cp libkrun/target/release/libkrun.so.$full_version "libkrun.so.$abi_version"
+            patchelf --set-rpath '$ORIGIN' "libkrun.so.$abi_version"
+            patchelf --set-needed "libkrunfw.so.4" "libkrun.so.$abi_version"
+            ln -sf "libkrun.so.$abi_version" "libkrun.so"
+            ;;
+        Darwin)
+            cp libkrun/target/release/libkrun.$full_version.dylib "libkrun.$abi_version.dylib"
+            install_name_tool -id "@rpath/libkrun.$abi_version.dylib" "libkrun.$abi_version.dylib"
+            install_name_tool -change "libkrunfw.4.dylib" "@rpath/libkrunfw.4.dylib" "libkrun.$abi_version.dylib"
+            ln -sf "libkrun.$abi_version.dylib" "libkrun.dylib"
+            ;;
+        *)
+            error "Unsupported OS: $OS_TYPE"
+            exit 1
+            ;;
+    esac
+    check_success "Failed to copy libkrun"
 }
 
 # Main script execution
@@ -285,14 +336,14 @@ check_existing_lib "libkrunfw"
 if [ $? -eq 0 ]; then
     create_build_directory
     clone_repo "$LIBKRUNFW_REPO" "libkrunfw"
-    build_and_install_lib "libkrunfw"
+    build_libkrunfw
 fi
 
 check_existing_lib "libkrun"
 if [ $? -eq 0 ]; then
     create_build_directory
     clone_repo "$LIBKRUN_REPO" "libkrun"
-    build_and_install_lib "libkrun"
+    build_libkrun
 fi
 
 # Finished

--- a/install_monocore.sh
+++ b/install_monocore.sh
@@ -1,36 +1,318 @@
 #!/bin/sh
 
-set -e
+# install_monocore.sh
+# ------------------
+# This script downloads and installs monocore binaries and libraries for the user's platform.
+#
+# Usage:
+#   ./install_monocore.sh [options]
+#
+# Options:
+#   --version       Specify version to install (default: 0.1.0)
+#   --no-cleanup   Skip cleanup of temporary files after installation
+#
+# The script performs the following tasks:
+#   1. Detects OS and architecture
+#   2. Downloads appropriate release archive from GitHub
+#   3. Verifies checksum
+#   4. Installs binaries to ~/.local/bin
+#   5. Installs libraries to ~/.local/lib
+#   6. Creates unversioned library symlinks
+#
+# Installation Paths:
+#   Binaries: ~/.local/bin/
+#   Libraries: ~/.local/lib/
 
-# Create directory from MONOCORE_HOME environment variable, default to $HOME/.monocore
-MONOCORE_DIR="${MONOCORE_HOME:-$HOME/.monocore}"
-mkdir -p "$MONOCORE_DIR"
+# Color variables
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RESET="\033[0m"
+
+# Logging functions
+info() {
+    printf "${GREEN}:: %s${RESET}\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}:: %s${RESET}\n" "$1"
+}
+
+error() {
+    printf "${RED}:: %s${RESET}\n" "$1"
+}
+
+# Default values
+VERSION="0.1.0"
+NO_CLEANUP=false
+TEMP_DIR="/tmp/monocore-install"
+GITHUB_REPO="appcypher/monocore"
+
+# Installation directories
+BIN_DIR="$HOME/.local/bin"
+LIB_DIR="$HOME/.local/lib"
+
+# Parse command line arguments
+for arg in "$@"; do
+    case $arg in
+        --version=*)
+            VERSION="${arg#*=}"
+            shift
+            ;;
+        --no-cleanup)
+            NO_CLEANUP=true
+            shift
+            ;;
+    esac
+done
+
+# Function to check command existence
+check_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        error "Required command '$1' not found. Please install it first."
+        exit 1
+    fi
+}
+
+# Check required commands
+check_command curl
+check_command tar
+check_command shasum
 
 # Detect OS and architecture
-OS="unknown"
-ARCH="unknown"
+detect_platform() {
+    OS="unknown"
+    ARCH="unknown"
 
-case "$(uname -s)" in
-    Linux*)     OS="Linux";;
-    Darwin*)    OS="macOS";;
-    *)          OS="unsupported";;
-esac
+    case "$(uname -s)" in
+        Linux*)     OS="linux";;
+        Darwin*)    OS="darwin";;
+        *)          error "Unsupported operating system: $(uname -s)"; exit 1;;
+    esac
 
-case "$(uname -m)" in
-    x86_64)     ARCH="x86_64";;
-    arm64)      ARCH="arm64";;
-    aarch64)    ARCH="aarch64";;
-    *)          ARCH="unknown";;
-esac
+    case "$(uname -m)" in
+        x86_64)     ARCH="x86_64";;
+        arm64)      ARCH="arm64";;
+        aarch64)    ARCH="aarch64";;
+        *)          error "Unsupported architecture: $(uname -m)"; exit 1;;
+    esac
 
-if [ "$OS" = "unsupported" ]; then
-    echo "Unsupported operating system. Exiting."
-    exit 1
-fi
+    # Normalize architecture for Darwin
+    if [ "$OS" = "darwin" ] && [ "$ARCH" = "aarch64" ]; then
+        ARCH="arm64"
+    fi
 
-# Write Hello World to hello_world.txt with OS and Arch info
-HELLO_FILE="$MONOCORE_DIR/hello_world.txt"
-echo "Hello World ${OS} ${ARCH}!" > "$HELLO_FILE"
+    PLATFORM="${OS}-${ARCH}"
+    ARCHIVE_NAME="monocore-${VERSION}-${PLATFORM}.tar.gz"
+    CHECKSUM_FILE="${ARCHIVE_NAME}.sha256"
+}
 
-# Output completion message
-echo "Installation complete. File created at $HELLO_FILE"
+# Cleanup function
+cleanup() {
+    if [ "$NO_CLEANUP" = true ]; then
+        info "Skipping cleanup as requested"
+        return
+    fi
+
+    info "Cleaning up temporary files..."
+    rm -rf "$TEMP_DIR"
+}
+
+# Set up trap for cleanup
+trap cleanup EXIT
+
+# Create necessary directories
+create_directories() {
+    info "Creating installation directories..."
+    mkdir -p "$BIN_DIR" "$LIB_DIR" "$TEMP_DIR"
+    if [ $? -ne 0 ]; then
+        error "Failed to create directories"
+        exit 1
+    fi
+}
+
+# Download files from GitHub
+download_files() {
+    info "Downloading monocore ${VERSION} for ${PLATFORM}..."
+
+    BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/monocore-v${VERSION}"
+
+    cd "$TEMP_DIR" || exit 1
+
+    # Download archive with progress bar
+    curl -L -# -o "${ARCHIVE_NAME}" "${BASE_URL}/${ARCHIVE_NAME}" || { error "Failed to download archive"; exit 1; }
+
+    # Download checksum silently
+    curl -L -s -o "${CHECKSUM_FILE}" "${BASE_URL}/${CHECKSUM_FILE}" || { error "Failed to download checksum"; exit 1; }
+}
+
+# Verify checksum
+verify_checksum() {
+    info "Verifying checksum..."
+    cd "$TEMP_DIR" || exit 1
+
+    # Redirect detailed output to /dev/null but keep the exit status
+    if ! (shasum -a 256 -c "$CHECKSUM_FILE" >/dev/null 2>&1); then
+        error "Checksum verification failed"
+        exit 1
+    fi
+}
+
+# Extract and install files
+install_files() {
+    info "Extracting files..."
+    cd "$TEMP_DIR" || exit 1
+
+    tar xzf "$ARCHIVE_NAME" || { error "Failed to extract archive"; exit 1; }
+
+    EXTRACT_DIR="monocore-${VERSION}-${PLATFORM}"
+    cd "$EXTRACT_DIR" || { error "Failed to enter extract directory"; exit 1; }
+
+    # Install binaries
+    info "Installing binaries..."
+    install -m 755 monocore "$BIN_DIR/" || { error "Failed to install monocore"; exit 1; }
+    install -m 755 monokrun "$BIN_DIR/" || { error "Failed to install monokrun"; exit 1; }
+
+    # Create mc symlink
+    ln -sf "$BIN_DIR/monocore" "$BIN_DIR/mc" || { error "Failed to create mc symlink"; exit 1; }
+
+    # Install libraries
+    info "Installing libraries..."
+    if [ "$OS" = "darwin" ]; then
+        # Install versioned dylibs
+        for lib in *.dylib; do
+            install -m 755 "$lib" "$LIB_DIR/" || { error "Failed to install $lib"; exit 1; }
+        done
+
+        # Create unversioned symlinks
+        cd "$LIB_DIR" || exit 1
+        ln -sf libkrun.*.dylib libkrun.dylib
+        ln -sf libkrunfw.*.dylib libkrunfw.dylib
+    else
+        # Install versioned shared objects
+        for lib in *.so.*; do
+            install -m 755 "$lib" "$LIB_DIR/" || { error "Failed to install $lib"; exit 1; }
+        done
+
+        # Create unversioned symlinks
+        cd "$LIB_DIR" || exit 1
+        ln -sf libkrun.so.* libkrun.so
+        ln -sf libkrunfw.so.* libkrunfw.so
+    fi
+}
+
+# Function to check if a line exists in a file
+line_exists() {
+    grep -Fxq "$1" "$2" 2>/dev/null
+}
+
+# Function to add environment config for sh/bash/zsh
+setup_posix_shell() {
+    local shell_rc="$1"
+    local shell_name="$2"
+    local lib_path_var="$3"
+
+    info "Setting up $shell_name configuration..."
+
+    # Create the file if it doesn't exist
+    touch "$shell_rc"
+
+    # PATH configuration
+    if ! line_exists 'export PATH="$HOME/.local/bin:$PATH"' "$shell_rc"; then
+        echo >> "$shell_rc"
+        echo '# Added by monocore installer' >> "$shell_rc"
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
+    fi
+
+    # Library path configuration
+    if ! line_exists "export $lib_path_var=\"\$HOME/.local/lib:\$$lib_path_var\"" "$shell_rc"; then
+        echo "export $lib_path_var=\"\$HOME/.local/lib:\$$lib_path_var\"" >> "$shell_rc"
+    fi
+}
+
+# Function to set up fish shell
+setup_fish() {
+    local fish_config="$HOME/.config/fish/config.fish"
+    local lib_path_var="$1"
+
+    info "Setting up fish configuration..."
+
+    # Create config directory if it doesn't exist
+    mkdir -p "$(dirname "$fish_config")"
+    touch "$fish_config"
+
+    # PATH configuration
+    if ! line_exists "set -gx PATH $HOME/.local/bin \$PATH" "$fish_config"; then
+        echo >> "$fish_config"
+        echo '# Added by monocore installer' >> "$fish_config"
+        echo "set -gx PATH $HOME/.local/bin \$PATH" >> "$fish_config"
+    fi
+
+    # Library path configuration
+    if ! line_exists "set -gx $lib_path_var $HOME/.local/lib \$$lib_path_var" "$fish_config"; then
+        echo "set -gx $lib_path_var $HOME/.local/lib \$$lib_path_var" >> "$fish_config"
+    fi
+}
+
+# Add this function near the other utility functions
+check_shell() {
+    command -v "$1" >/dev3/null 2>&1
+}
+
+# Function to configure shell environment
+configure_shell_env() {
+    info "Configuring detected shells..."
+
+    # Determine library path variable based on OS
+    local lib_path_var
+    case "$(uname -s)" in
+        Linux*)     lib_path_var="LD_LIBRARY_PATH";;
+        Darwin*)    lib_path_var="DYLD_LIBRARY_PATH";;
+        *)          warn "Unsupported OS for environment configuration"; return 1;;
+    esac
+
+    # Configure bash if installed
+    if check_shell bash; then
+        setup_posix_shell "$HOME/.bashrc" "bash" "$lib_path_var"
+    fi
+
+    # Configure zsh if installed
+    if check_shell zsh; then
+        setup_posix_shell "$HOME/.zshrc" "zsh" "$lib_path_var"
+    fi
+
+    # Configure fish if installed
+    if check_shell fish; then
+        setup_fish "$lib_path_var"
+    fi
+
+    # Always configure .profile for POSIX shell compatibility
+    setup_posix_shell "$HOME/.profile" "sh" "$lib_path_var"
+
+    info "All detected shell environments configured. Please restart your shell or source your shell's config file"
+}
+
+# Main installation process
+main() {
+    info "Starting monocore installation..."
+
+    detect_platform
+    create_directories
+    download_files
+    verify_checksum
+    install_files
+
+    # Configure shell environment
+    configure_shell_env
+    if [ $? -ne 0 ]; then
+        warn "Shell environment configuration failed, but installation completed"
+    fi
+
+    info "Installation completed successfully!"
+    info "Binaries installed to: $BIN_DIR"
+    info "Libraries installed to: $LIB_DIR"
+    info "Please restart your shell or source your shell's config file to use monocore"
+}
+
+# Run main installation
+main

--- a/install_monocore.sh
+++ b/install_monocore.sh
@@ -19,7 +19,7 @@ esac
 case "$(uname -m)" in
     x86_64)     ARCH="x86_64";;
     arm64)      ARCH="arm64";;
-    aarch64)    ARCH="arm64";;
+    aarch64)    ARCH="aarch64";;
     *)          ARCH="unknown";;
 esac
 

--- a/monocore/Makefile
+++ b/monocore/Makefile
@@ -16,8 +16,7 @@ BUILD_DIR := build
 BENCHES_DIR := ../target/release
 
 # Library paths
-DARWIN_LIB_PATH := /usr/local/lib
-LINUX_LIB_PATH := /usr/local/lib64
+LIB_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../lib)
 
 # Phony targets
 .PHONY: all install clean example bench monokrun bin _run_bin monocore deps
@@ -31,10 +30,10 @@ monokrun: $(MONOKRUN_RELEASE_BIN)
 $(MONOCORE_RELEASE_BIN): deps
 	@mkdir -p $(BUILD_DIR)
 ifeq ($(OS),Darwin)
-	cargo build --release --bin monocore $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib" cargo build --release --bin monocore $(FEATURES)
 	codesign --entitlements monocore/monocore.entitlements --force -s - $@
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,$(LINUX_LIB_PATH)" cargo build --release --bin monocore $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib" cargo build --release --bin monocore $(FEATURES)
 ifdef OVERLAYFS
 	sudo setcap cap_sys_admin+ep $@
 endif
@@ -42,10 +41,10 @@ endif
 
 $(MONOKRUN_RELEASE_BIN): deps
 ifeq ($(OS),Darwin)
-	cargo build --release --bin monokrun $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib" cargo build --release --bin monokrun $(FEATURES)
 	codesign --entitlements monocore/monocore.entitlements --force -s - $@
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,$(LINUX_LIB_PATH)" cargo build --release --bin monokrun $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib" cargo build --release --bin monokrun $(FEATURES)
 ifdef OVERLAYFS
 	sudo setcap cap_sys_admin+ep $@
 endif
@@ -73,11 +72,11 @@ example: monokrun
 
 _run_example:
 ifeq ($(OS),Darwin)
-	cargo build --example $(EXAMPLE_NAME) --release
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib" cargo build --example $(EXAMPLE_NAME) --release
 	codesign --entitlements monocore.entitlements --force -s - $(EXAMPLES_DIR)/$(EXAMPLE_NAME)
-	DYLD_LIBRARY_PATH=$(DARWIN_LIB_PATH):$$RUST_DYLD_LIBRARY_PATH $(EXAMPLES_DIR)/$(EXAMPLE_NAME) $(ARGS) || exit $$?
+	DYLD_LIBRARY_PATH=$(LIB_DIR):$$DYLD_LIBRARY_PATH $(EXAMPLES_DIR)/$(EXAMPLE_NAME) $(ARGS) || exit $$?
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,$(LINUX_LIB_PATH)" LD_LIBRARY_PATH=$(LINUX_LIB_PATH):$$LD_LIBRARY_PATH cargo run --example $(EXAMPLE_NAME) --release -- $(ARGS) || exit $$?
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib" cargo run --example $(EXAMPLE_NAME) --release -- $(ARGS) || exit $$?
 endif
 
 # Run benchmarks
@@ -102,16 +101,16 @@ bin: monokrun
 
 _run_bin:
 ifeq ($(OS),Darwin)
-	cargo build --bin $(BIN_NAME) --release
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib" cargo build --bin $(BIN_NAME) --release
 	codesign --entitlements monocore.entitlements --force -s - $(BENCHES_DIR)/$(BIN_NAME)
-	DYLD_LIBRARY_PATH=$(DARWIN_LIB_PATH):$$RUST_DYLD_LIBRARY_PATH $(BENCHES_DIR)/$(BIN_NAME) $(ARGS) || exit $$?
+	DYLD_LIBRARY_PATH=$(LIB_DIR):$$DYLD_LIBRARY_PATH $(BENCHES_DIR)/$(BIN_NAME) $(ARGS) || exit $$?
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,$(LINUX_LIB_PATH)" LD_LIBRARY_PATH=$(LINUX_LIB_PATH):$$LD_LIBRARY_PATH cargo run --bin $(BIN_NAME) --release -- $(ARGS) || exit $$?
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib" cargo run --bin $(BIN_NAME) --release -- $(ARGS) || exit $$?
 endif
 
 # Build dependencies (libkrunfw and libkrun)
 deps:
-	@if [ ! -f "$(DARWIN_LIB_PATH)/libkrun.dylib" ] && [ ! -f "$(LINUX_LIB_PATH)/libkrun.so" ]; then \
+	@if [ ! -f "$(LIB_DIR)/libkrun.dylib" ] && [ ! -f "$(LIB_DIR)/libkrun.so" ]; then \
 		./build_libkrun.sh; \
 	fi
 

--- a/monocore/build.rs
+++ b/monocore/build.rs
@@ -1,8 +1,37 @@
+use std::{env, path::Path};
+
 fn main() {
-    // Add search paths for libkrunfw and libkrun dynamic libraries
-    if cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-search=/usr/local/lib64");
-    } else if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-search=/usr/local/lib");
-    }
+    // Get the manifest directory (where Cargo.toml lives)
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let build_dir = Path::new(&manifest_dir).parent().unwrap().join("build");
+
+    // Print current directory and build directory for debugging
+    println!(
+        "cargo:warning=Current dir: {:?}",
+        std::env::current_dir().unwrap()
+    );
+    println!("cargo:warning=Build dir: {:?}", build_dir);
+
+    // Add build directory as first search path
+    println!("cargo:rustc-link-search=native={}", build_dir.display());
+
+    // Add system paths as fallback
+    println!("cargo:rustc-link-search=native=/usr/local/lib");
+    println!(
+        "cargo:rustc-link-search=native={}/.local/lib",
+        env::var("HOME").unwrap()
+    );
+
+    // Link against library
+    println!("cargo:rustc-link-lib=dylib=krun");
+
+    // Force rebuild if the library changes
+    println!(
+        "cargo:rerun-if-changed={}",
+        build_dir.join("libkrun.dylib").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        build_dir.join("libkrun.so").display()
+    );
 }

--- a/package_monocore.sh
+++ b/package_monocore.sh
@@ -124,19 +124,21 @@ tar -czvf "$BUILD_DIR/$PACKAGE_NAME.tar.gz" -C "$BUILD_DIR" "$PACKAGE_NAME"
 check_success "Failed to create tarball"
 
 info "Generating SHA256 checksum..."
+cd "$BUILD_DIR" || error "Failed to change to build directory"
+
 if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$BUILD_DIR/$PACKAGE_NAME.tar.gz" > "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    sha256sum "$PACKAGE_NAME.tar.gz" | sed "s|$BUILD_DIR/||" > "$PACKAGE_NAME.tar.gz.sha256"
     check_success "Failed to generate SHA256 checksum"
 
     info "Verifying checksum..."
-    sha256sum -c "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    sha256sum -c "$PACKAGE_NAME.tar.gz.sha256" >/dev/null 2>&1
     check_success "Checksum verification failed"
 else
-    shasum -a 256 "$BUILD_DIR/$PACKAGE_NAME.tar.gz" > "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    shasum -a 256 "$PACKAGE_NAME.tar.gz" | sed "s|$BUILD_DIR/||" > "$PACKAGE_NAME.tar.gz.sha256"
     check_success "Failed to generate SHA256 checksum"
 
     info "Verifying checksum..."
-    shasum -a 256 -c "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    shasum -a 256 -c "$PACKAGE_NAME.tar.gz.sha256" >/dev/null 2>&1
     check_success "Checksum verification failed"
 fi
 

--- a/package_monocore.sh
+++ b/package_monocore.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+
+# package_monocore.sh
+# ------------------
+# This script packages monocore and its dependencies into a distributable tarball.
+#
+# Usage:
+#   ./package_monocore.sh <semver>
+#
+# Arguments:
+#   semver    Semantic version for the package (required, e.g., 0.1.0)
+#
+# The script performs the following tasks:
+#   1. Builds monocore and its dependencies
+#   2. Creates a versioned directory with OS and architecture info
+#   3. Copies all necessary binaries and libraries
+#   4. Creates a tarball and its SHA256 checksum
+#
+# Example:
+#   ./package_monocore.sh 0.1.0
+
+# Color variables
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RESET="\033[0m"
+
+# Logging functions
+info() {
+    printf "${GREEN}:: %s${RESET}\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}:: %s${RESET}\n" "$1"
+}
+
+error() {
+    printf "${RED}:: %s${RESET}\n" "$1"
+    exit 1
+}
+
+# Check for required semver argument
+if [ $# -ne 1 ]; then
+    error "Usage: $0 <semver>"
+fi
+
+SEMVER="$1"
+# Validate semver format (basic check)
+if ! echo "$SEMVER" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+    error "Invalid semver format. Expected format: X.Y.Z (e.g., 0.1.0)"
+fi
+
+# Determine OS and architecture
+OS_TYPE="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    arm64)
+        ARCH="arm64"
+        ;;
+esac
+
+# Set up variables
+ORIGINAL_DIR="$(pwd)"
+BUILD_DIR="$ORIGINAL_DIR/build"
+PACKAGE_NAME="monocore-${SEMVER}-${OS_TYPE}-${ARCH}"
+PACKAGE_DIR="$BUILD_DIR/$PACKAGE_NAME"
+
+# Function to check command success
+check_success() {
+    if [ $? -ne 0 ]; then
+        error "Error occurred: $1"
+    fi
+}
+
+# Build monocore and dependencies
+info "Building monocore..."
+make build
+check_success "Failed to build monocore"
+
+# Create package directory
+info "Creating package directory..."
+mkdir -p "$PACKAGE_DIR"
+check_success "Failed to create package directory"
+
+info "Copying binaries..."
+# Copy monocore and monokrun
+cp "$BUILD_DIR/monocore" "$PACKAGE_DIR/"
+check_success "Failed to copy monocore binary"
+cp "$BUILD_DIR/monokrun" "$PACKAGE_DIR/"
+check_success "Failed to copy monokrun binary"
+
+# Copy libraries based on OS type
+info "Copying libraries..."
+if [ "$OS_TYPE" = "darwin" ]; then
+    # Find and copy libkrun
+    LIBKRUN=$(find "$BUILD_DIR" -maxdepth 1 -name "libkrun.*.dylib" | head -n 1)
+    cp "$LIBKRUN" "$PACKAGE_DIR/$(basename "$LIBKRUN")"
+    check_success "Failed to copy libkrun"
+
+    # Find and copy libkrunfw
+    LIBKRUNFW=$(find "$BUILD_DIR" -maxdepth 1 -name "libkrunfw.*.dylib" | head -n 1)
+    cp "$LIBKRUNFW" "$PACKAGE_DIR/$(basename "$LIBKRUNFW")"
+    check_success "Failed to copy libkrunfw"
+else
+    # Find and copy libkrun
+    LIBKRUN=$(find "$BUILD_DIR" -maxdepth 1 -name "libkrun.so.*" | head -n 1)
+    cp "$LIBKRUN" "$PACKAGE_DIR/$(basename "$LIBKRUN")"
+    check_success "Failed to copy libkrun"
+
+    # Find and copy libkrunfw
+    LIBKRUNFW=$(find "$BUILD_DIR" -maxdepth 1 -name "libkrunfw.so.*" | head -n 1)
+    cp "$LIBKRUNFW" "$PACKAGE_DIR/$(basename "$LIBKRUNFW")"
+    check_success "Failed to copy libkrunfw"
+fi
+
+info "Creating tarball..."
+tar -czvf "$BUILD_DIR/$PACKAGE_NAME.tar.gz" -C "$BUILD_DIR" "$PACKAGE_NAME"
+check_success "Failed to create tarball"
+
+info "Generating SHA256 checksum..."
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$BUILD_DIR/$PACKAGE_NAME.tar.gz" > "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    check_success "Failed to generate SHA256 checksum"
+
+    info "Verifying checksum..."
+    sha256sum -c "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    check_success "Checksum verification failed"
+else
+    shasum -a 256 "$BUILD_DIR/$PACKAGE_NAME.tar.gz" > "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    check_success "Failed to generate SHA256 checksum"
+
+    info "Verifying checksum..."
+    shasum -a 256 -c "$BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"
+    check_success "Checksum verification failed"
+fi
+
+info "Package created successfully:"
+info "  - $BUILD_DIR/$PACKAGE_NAME.tar.gz"
+info "  - $BUILD_DIR/$PACKAGE_NAME.tar.gz.sha256"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+
+# setup_env.sh
+# -----------
+# This script configures the user's shell environment to include ~/.local/bin
+# and ~/.local/lib in the appropriate path variables.
+#
+# Usage:
+#   ./setup_env.sh [options]
+#
+# Options:
+#   --force    Force update even if paths are already configured
+#
+# Supported shells:
+#   - bash
+#   - zsh
+#   - fish
+#   - sh
+#
+# The script performs the following tasks:
+#   1. Detects user's shell
+#   2. Creates ~/.local/bin and ~/.local/lib if they don't exist
+#   3. Updates appropriate shell config files
+#   4. Sets up PATH and library paths (LD_LIBRARY_PATH/DYLD_LIBRARY_PATH)
+
+# Color variables
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RESET="\033[0m"
+
+# Logging functions
+info() {
+    printf "${GREEN}:: %s${RESET}\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}:: %s${RESET}\n" "$1"
+}
+
+error() {
+    printf "${RED}:: %s${RESET}\n" "$1"
+}
+
+# Default values
+FORCE=false
+
+# Parse command line arguments
+for arg in "$@"; do
+    case $arg in
+        --force)
+            FORCE=true
+            shift
+            ;;
+    esac
+done
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)     LIB_PATH_VAR="LD_LIBRARY_PATH";;
+    Darwin*)    LIB_PATH_VAR="DYLD_LIBRARY_PATH";;
+    *)          error "Unsupported operating system: $OS"; exit 1;;
+esac
+
+# Create directories if they don't exist
+create_directories() {
+    info "Creating local directories if needed..."
+    mkdir -p "$HOME/.local/bin" "$HOME/.local/lib"
+    if [ $? -ne 0 ]; then
+        error "Failed to create directories"
+        exit 1
+    fi
+}
+
+# Function to check if a line exists in a file
+line_exists() {
+    grep -Fxq "$1" "$2" 2>/dev/null
+}
+
+# Function to add environment config for sh/bash/zsh
+setup_posix_shell() {
+    local shell_rc="$1"
+    local shell_name="$2"
+
+    info "Setting up $shell_name configuration..."
+
+    # Check if config file exists
+    if [ ! -f "$shell_rc" ]; then
+        info "Creating new config file: $shell_rc"
+        mkdir -p "$(dirname "$shell_rc")"
+        echo "# Created by monocore setup" > "$shell_rc"
+        echo >> "$shell_rc"
+    fi
+
+    # PATH configuration
+    if ! line_exists 'export PATH="$HOME/.local/bin:$PATH"' "$shell_rc" || [ "$FORCE" = true ]; then
+        echo >> "$shell_rc"
+        echo '# Added by setup_env.sh' >> "$shell_rc"
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
+        info "Added PATH configuration to $shell_rc"
+    fi
+
+    # Library path configuration
+    if ! line_exists "export $LIB_PATH_VAR=\"\$HOME/.local/lib:\$$LIB_PATH_VAR\"" "$shell_rc" || [ "$FORCE" = true ]; then
+        echo "export $LIB_PATH_VAR=\"\$HOME/.local/lib:\$$LIB_PATH_VAR\"" >> "$shell_rc"
+        info "Added library path configuration to $shell_rc"
+    fi
+}
+
+# Function to set up fish shell
+setup_fish() {
+    local fish_config="$HOME/.config/fish/config.fish"
+
+    info "Setting up fish configuration..."
+
+    # Check if config directory and file exist
+    if [ ! -f "$fish_config" ]; then
+        info "Creating new fish config file: $fish_config"
+        mkdir -p "$(dirname "$fish_config")"
+        echo "# Created by monocore setup" > "$fish_config"
+        echo >> "$fish_config"
+    fi
+
+    # PATH configuration
+    if ! line_exists "set -gx PATH $HOME/.local/bin \$PATH" "$fish_config" || [ "$FORCE" = true ]; then
+        echo >> "$fish_config"
+        echo '# Added by setup_env.sh' >> "$fish_config"
+        echo "set -gx PATH $HOME/.local/bin \$PATH" >> "$fish_config"
+        info "Added PATH configuration to $fish_config"
+    fi
+
+    # Library path configuration
+    if ! line_exists "set -gx $LIB_PATH_VAR $HOME/.local/lib \$$LIB_PATH_VAR" "$fish_config" || [ "$FORCE" = true ]; then
+        echo "set -gx $LIB_PATH_VAR $HOME/.local/lib \$$LIB_PATH_VAR" >> "$fish_config"
+        info "Added library path configuration to $fish_config"
+    fi
+}
+
+# Add this function to check if a program exists
+check_shell() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Main setup function
+setup_shell_env() {
+    create_directories
+
+    info "Configuring detected shells..."
+
+    # Configure bash if installed
+    if check_shell bash; then
+        setup_posix_shell "$HOME/.bashrc" "bash"
+    fi
+
+    # Configure zsh if installed
+    if check_shell zsh; then
+        setup_posix_shell "$HOME/.zshrc" "zsh"
+    fi
+
+    # Configure fish if installed
+    if check_shell fish; then
+        setup_fish
+    fi
+
+    # Always configure .profile for POSIX shell compatibility
+    setup_posix_shell "$HOME/.profile" "sh"
+
+    info "Environment setup complete for detected shells!"
+    info "Please restart your shell or source your shell's config file"
+}
+
+# Run main setup
+setup_shell_env


### PR DESCRIPTION
# Description

This PR significantly improves the installation experience by making it simpler and sudo-less by leveraging `~/.local` directories. The changes set up the project for a future `curl | sh` style installation while maintaining security and portability.

Key changes:
- Moves installation from system directories (`/usr/local`) to user's home (`~/.local`)
- Updates build system to use relative RPATHs for libraries
- Adds new installation and environment setup scripts
- Improves build process to package releases properly
- Updates gitignore and build configuration for better organization

## Link to issue

- Part of larger effort to fix #51, #55, #56 and improve DX 

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Test plan (required)

Tested the following installation flows:

1. Clean installation:

```
make build install
```

- Verified binaries installed to ~/.local/bin
- Verified libraries installed to ~/.local/lib
- Confirmed mc symlink created
- Tested binary execution with relative library paths

2. Environment setup:
```
./setup_env.sh
```

- Tested with bash, zsh, and fish shells
- Verified PATH and library path updates
- Confirmed changes persist after shell restart

3. Package creation and installation:
```
./package_monocore.sh 0.1.0
./install_monocore.sh
```

- Verified package contents and checksums
- Tested installation from package
- Confirmed all components work after package installation

4. Build system:
- Tested on both Linux and macOS
- Tested with both x86_64 and arm64 architectures

## Screenshots/Screencaps

N/A
