### PR TITLE
chore(deps): update monoutils-store version and skip GitHub release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ procspawn = "1.0"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 reqwest-middleware = "0.3" # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
 reqwest-retry = "0.6" # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-retry/issues/100
-monoutils-store = { version = "0.1.0", path = "./monoutils-store" }
+monoutils-store = { version = "0.2.0", path = "./monoutils-store" }
 chrono = { version = "0.4", features = ["serde"] }
 criterion = "0.5"
 test-log = "0.2"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,10 +8,12 @@
     },
     "monofs": {
       "package-name": "monofs",
+      "skip-github-release": true,
       "release-type": "rust"
     },
     "monoutils-store": {
       "package-name": "monoutils-store",
+      "skip-github-release": true,
       "release-type": "rust"
     }
   },


### PR DESCRIPTION
# Description

Updates the `monoutils-store` dependency from v0.1.0 to v0.2.0 and modifies the release-please configuration to skip GitHub releases for `monofs` and `monoutils-store` packages.

## Link to issue

N/A - Maintenance update

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

1. Run the full test suite to ensure the dependency update doesn't introduce any regressions
2. Verify that release-please still works correctly with the updated configuration
