### PR TITLE
chore: update version in install script and enhance release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,21 @@ make build
 make install
 ```
 
+### Release Process
+
+When a release-please PR is created, the following manual changes need to be made before merging:
+
+1. **Update Internal Dependencies**: In the root `Cargo.toml`, ensure that any internal crate dependencies use the new release version being created. For example:
+
+   ```toml
+   [dependencies]
+   monoutils-x = { version = "0.2.0", path = "monoutils-x" }  # Update this version
+   ```
+
+2. **Update Install Script Version**: In `install_monocore.sh`, update the version number to match the new release version.
+
+These changes are not automatically handled by release-please and must be made manually before merging the release PR.
+
 ## 📚 Documentation
 
 - [Detailed Features](monocore/README.md#features)

--- a/install_monocore.sh
+++ b/install_monocore.sh
@@ -8,7 +8,7 @@
 #   ./install_monocore.sh [options]
 #
 # Options:
-#   --version       Specify version to install (default: 0.1.0)
+#   --version       Specify version to install (default: 0.2.0)
 #   --no-cleanup   Skip cleanup of temporary files after installation
 #
 # The script performs the following tasks:
@@ -43,7 +43,7 @@ error() {
 }
 
 # Default values
-VERSION="0.1.0"
+VERSION="0.2.0"
 NO_CLEANUP=false
 TEMP_DIR="/tmp/monocore-install"
 GITHUB_REPO="appcypher/monocore"


### PR DESCRIPTION
# Description

Updates the release process documentation and version numbers across the repository:

1. Added detailed release process documentation to README.md explaining manual steps needed for release-please PRs
2. Updated version numbers from 0.1.0 to 0.2.0 in the install script (install_monocore.sh)

These changes improve the release process documentation and keep version numbers consistent across the project.

## Link to issue

N/A - Documentation and maintenance update

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)
- [x] This change requires a documentation update

## Test plan (required)

1. Verify the install script works with the updated version number:   ```bash
   ./install_monocore.sh
   ./install_monocore.sh --version 0.2.0   ```
2. Review the added release process documentation in README.md to ensure accuracy
3. Confirm all version numbers are consistently updated to 0.2.0
