### PR TITLE
refactor(monofs): improve directory entry versioning and deletion handling

### DIFF
--- a/monofs/README.md
+++ b/monofs/README.md
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 #### Working with Directories
 
 ```rust
-use monofs::filesystem::{Dir, File, FsResult};
+use monofs::filesystem::{Dir, FsResult};
 use monoutils_store::{MemoryStore, Storable};
 
 #[tokio::main]
@@ -94,10 +94,10 @@ async fn main() -> FsResult<()> {
     let mut root = Dir::new(store.clone());
 
     // Create a file in the directory
-    root.put_file("example.txt", File::new(store.clone()))?;
+    root.create_file("example.txt").await?;
 
     // Create a subdirectory
-    root.put_dir("subdir", Dir::new(store.clone()))?;
+    root.create_dir("subdir").await?;
 
     // List directory contents
     for (name, entity) in root.get_entries() {

--- a/monofs/examples/dir_ops.rs
+++ b/monofs/examples/dir_ops.rs
@@ -38,8 +38,12 @@ async fn main() -> FsResult<()> {
     let mut root = Dir::new(store.clone());
     println!("Created root directory: {:?}", root);
 
-    // Find or create a file
-    let file = root.find_or_create("docs/readme.md", true).await?;
+    // Create a directory
+    let dir = root.create_dir("docs").await?;
+    println!("Created directory: {:?}", dir);
+
+    // Create a file
+    let file = root.create_file("docs/readme.md").await?;
     println!("Created file: {:?}", file);
 
     // Find or create a directory
@@ -63,11 +67,13 @@ async fn main() -> FsResult<()> {
     println!("Removed 'docs/readme.md'");
 
     // Create and add a subdirectory
-    root.put_dir("subdir", Dir::new(store.clone()))?;
+    root.put_adapted_dir("subdir", Dir::new(store.clone()))
+        .await?;
     println!("Added subdirectory 'subdir'");
 
     // Create and add a file to the root directory
-    root.put_file("example.txt", File::new(store.clone()))?;
+    root.put_adapted_file("example.txt", File::new(store.clone()))
+        .await?;
     println!("Added file 'example.txt' to root");
 
     // List entries in the root directory
@@ -82,7 +88,9 @@ async fn main() -> FsResult<()> {
 
     // Get and modify a subdirectory
     if let Some(subdir) = root.get_dir_mut("subdir").await? {
-        subdir.put_file("subdir_file.txt", File::new(store.clone()))?;
+        subdir
+            .put_adapted_file("subdir_file.txt", File::new(store.clone()))
+            .await?;
         println!("Added 'subdir_file.txt' to 'subdir'");
     }
 

--- a/monofs/lib/filesystem/cidlink.rs
+++ b/monofs/lib/filesystem/cidlink.rs
@@ -195,13 +195,13 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Encoded { identifier, cached } => f
-                .debug_struct("CidLink")
+                .debug_struct("CidLink::Encoded")
                 .field("identifier", &identifier)
                 .field("cached", &cached.get())
                 .finish(),
             Self::Decoded(value) => f
-                .debug_struct("CidLink")
-                .field("identifier", &value)
+                .debug_tuple("CidLink::Decoded")
+                .field(&value)
                 .finish(),
         }
     }

--- a/monofs/lib/filesystem/dir/find.rs
+++ b/monofs/lib/filesystem/dir/find.rs
@@ -175,7 +175,7 @@ where
 
             for segment in components {
                 let new_dir = Dir::new(dir.get_store().clone());
-                dir.put_dir(segment.clone(), new_dir)?;
+                dir.put_adapted_dir(segment.clone(), new_dir).await?;
                 dir = dir.get_dir_mut(&segment).await?.unwrap();
             }
 
@@ -229,16 +229,16 @@ mod tests {
             let file2 = File::new(store.clone());
 
             let file1_cid = file1.store().await?;
-            subdir1.put_entry("file1.txt", file1_cid.into())?;
+            subdir1.put_adapted_entry("file1.txt", file1_cid.into()).await?;
 
             let file2_cid = file2.store().await?;
-            subdir2.put_entry("file2.txt", file2_cid.into())?;
+            subdir2.put_adapted_entry("file2.txt", file2_cid.into()).await?;
 
             let subdir2_cid = subdir2.store().await?;
-            subdir1.put_entry("subdir2", subdir2_cid.into())?;
+            subdir1.put_adapted_entry("subdir2", subdir2_cid.into()).await?;
 
             let subdir1_cid = subdir1.store().await?;
-            root.put_entry("subdir1", subdir1_cid.into())?;
+            root.put_adapted_entry("subdir1", subdir1_cid.into()).await?;
 
             Ok(root)
         }

--- a/monofs/lib/filesystem/entity.rs
+++ b/monofs/lib/filesystem/entity.rs
@@ -145,6 +145,15 @@ where
             Entity::SymPathLink(symlink) => symlink.get_store(),
         }
     }
+
+    pub(crate) fn set_previous(&mut self, previous: Option<Cid>) {
+        match self {
+            Entity::File(file) => file.set_previous(previous),
+            Entity::Dir(dir) => dir.set_previous(previous),
+            Entity::SymCidLink(symlink) => symlink.set_previous(previous),
+            Entity::SymPathLink(symlink) => symlink.set_previous(previous),
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -184,7 +193,7 @@ where
 
 impl<S> Debug for Entity<S>
 where
-    S: IpldStore,
+    S: IpldStore + Send + Sync,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/monofs/lib/filesystem/error.rs
+++ b/monofs/lib/filesystem/error.rs
@@ -116,6 +116,10 @@ pub enum FsError {
     /// Broken symbolic CID link.
     #[error("Broken symbolic CID link: {0}")]
     BrokenSymCidLink(Cid),
+
+    /// Invalid operation.
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
 }
 
 /// An error that can represent any error.

--- a/monofs/lib/filesystem/file.rs
+++ b/monofs/lib/filesystem/file.rs
@@ -382,6 +382,11 @@ where
             previous: self.inner.initial_load_cid.get().cloned(),
         })
     }
+
+    pub(crate) fn set_previous(&mut self, previous: Option<Cid>) {
+        let inner = Arc::make_mut(&mut self.inner);
+        inner.previous = previous;
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -411,6 +416,7 @@ where
         f.debug_struct("File")
             .field("metadata", &self.inner.metadata)
             .field("content", &self.inner.content)
+            .field("previous", &self.inner.previous)
             .finish()
     }
 }

--- a/monofs/lib/filesystem/sympathlink.rs
+++ b/monofs/lib/filesystem/sympathlink.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+use chrono::Utc;
 use monoutils_store::{
     ipld::cid::Cid, IpldReferences, IpldStore, Storable, StoreError, StoreResult,
 };
@@ -145,6 +146,7 @@ where
     pub fn set_target_path(&mut self, target_path: impl AsRef<str>) {
         let inner = Arc::make_mut(&mut self.inner);
         inner.target_path = Utf8UnixPathBuf::from(target_path.as_ref());
+        inner.metadata.set_modified_at(Utc::now());
     }
 
     /// Tries to create a new `SymPathLink` from a serializable representation.
@@ -180,6 +182,11 @@ where
             previous: self.inner.initial_load_cid.get().cloned(),
         })
     }
+
+    pub(crate) fn set_previous(&mut self, previous: Option<Cid>) {
+        let inner = Arc::make_mut(&mut self.inner);
+        inner.previous = previous;
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -209,6 +216,7 @@ where
         f.debug_struct("SymPathLink")
             .field("metadata", &self.inner.metadata)
             .field("target_path", &self.inner.target_path)
+            .field("previous", &self.inner.previous)
             .finish()
     }
 }


### PR DESCRIPTION
Changes:
- Changed Dir API to use async put_adapted_* methods instead of sync put_* methods
- Removed Dir.remove_trace() in favor of single Dir.remove() method
- Removed deleted_at from Metadata in favor of Entry.deleted flag
- Changed SyncType enum to include Default variant as default value
- Added Entry struct to track deletion status of directory entries
- Added versioning support to directory entries via put_adapted_* methods
- Simplified directory entry management with single remove() method
- Added convenience create_* methods for files, dirs and symlinks
- Updated examples and tests to use new async API
- Made debug implementations more detailed
- Added Default variant to SyncType enum
