### PR TITLE
feat(monofs): add checkpoint method to filesystem entities

### DIFF
--- a/monofs/examples/dir_ops.rs
+++ b/monofs/examples/dir_ops.rs
@@ -23,7 +23,7 @@
 //! ```
 
 use monofs::filesystem::{Dir, File, FsResult};
-use monoutils_store::{MemoryStore, Storable};
+use monoutils_store::MemoryStore;
 
 //--------------------------------------------------------------------------------------------------
 // Function: main
@@ -101,13 +101,9 @@ async fn main() -> FsResult<()> {
     // Check if the directory is empty
     println!("Root directory is empty: {}", root.is_empty());
 
-    // Store the root directory
-    let root_cid = root.store().await?;
-    println!("Stored root directory with CID: {}", root_cid);
-
-    // Load the root directory
-    let loaded_root = Dir::load(&root_cid, store).await?;
-    println!("Loaded root directory: {:?}", loaded_root);
+    // Checkpoint the root directory
+    root.checkpoint().await?;
+    println!("Checkpoint root directory: {:?}", root);
 
     Ok(())
 }

--- a/monofs/lib/filesystem/file/io.rs
+++ b/monofs/lib/filesystem/file/io.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use chrono::Utc;
 use futures::Future;
 use monoutils::{EmptySeekableReader, SeekableReader};
 use monoutils_store::{IpldStore, IpldStoreSeekable};
@@ -72,6 +73,7 @@ where
             let store = self.file.get_store();
             let cid = store.put_bytes(&self.buffer[..]).await.map(Into::into)?;
             self.file.set_content(Some(cid));
+            self.file.get_metadata_mut().set_modified_at(Utc::now());
             self.buffer.clear();
         }
         Ok(())


### PR DESCRIPTION
Add a new `checkpoint()` method to Dir, File, Entity, SymCidLink and SymPathLink that combines store() and load() operations into a single atomic operation. This simplifies the common pattern of storing and reloading entities to create new versions.

- Add checkpoint() method to all filesystem entities
- Update examples and tests to use checkpoint() instead of store()/load() pattern
- Fix move operation in Dir to avoid potential data loss during moves
- Update metadata modified timestamp when content changes
