### PR TITLE
refactor(store): improve store interface and chunking implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "libipld",
  "lru",
  "monoutils",
+ "pretty-error-debug",
  "rand",
  "serde",
  "serde_ipld_dagcbor",

--- a/monofs/examples/file_ops.rs
+++ b/monofs/examples/file_ops.rs
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
     drop(reader); // Drop reader to free up the input stream ref to the file
 
     // Check if the file is empty
-    println!("File is empty: {}", file.is_empty());
+    println!("File is empty: {}", file.is_empty().await?);
 
     // Get and print file metadata
     let metadata = file.get_metadata();
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
     // Truncate the file
     file.truncate();
     println!("Truncated file");
-    println!("File is empty after truncation: {}", file.is_empty());
+    println!("File is empty after truncation: {}", file.is_empty().await?);
 
     Ok(())
 }

--- a/monofs/lib/filesystem/entity.rs
+++ b/monofs/lib/filesystem/entity.rs
@@ -160,7 +160,7 @@ where
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let store = MemoryStore::default();
-    /// let file = File::with_content(store.clone(), b"Hello, World!".to_vec()).await;
+    /// let file = File::with_content(store.clone(), b"Hello, World!".as_slice()).await?;
     /// let mut entity = Entity::File(file);
     ///
     /// // Store and checkpoint the entity

--- a/monofs/lib/filesystem/symcidlink.rs
+++ b/monofs/lib/filesystem/symcidlink.rs
@@ -352,7 +352,7 @@ where
     /// let store = MemoryStore::default();
     ///
     /// // Create a file
-    /// let file = File::with_content(store.clone(), b"Hello, World!".to_vec()).await;
+    /// let file = File::with_content(store.clone(), b"Hello, World!".as_slice()).await?;
     /// let file_cid = file.store().await?;
     ///
     /// // Create a symlink to the file
@@ -433,7 +433,7 @@ where
     /// let store = MemoryStore::default();
     ///
     /// // Create a file
-    /// let file = File::with_content(store.clone(), b"Hello, World!".to_vec()).await;
+    /// let file = File::with_content(store.clone(), b"Hello, World!".as_slice()).await?;
     /// let file_cid = file.store().await?;
     ///
     /// // Create a symlink to the file
@@ -582,8 +582,7 @@ mod tests {
             let store = MemoryStore::default();
             let mut root_dir = Dir::new(store.clone());
 
-            let file_content = b"Hello, World!".to_vec();
-            let file = File::with_content(store.clone(), file_content).await;
+            let file = File::with_content(store.clone(), b"Hello, World!".as_slice()).await?;
 
             root_dir
                 .put_adapted_file("test_file.txt", file.clone())

--- a/monofs/lib/store/membufferstore.rs
+++ b/monofs/lib/store/membufferstore.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, pin::Pin};
 use bytes::Bytes;
 use monoutils_store::{
     ipld::cid::Cid, Codec, DualStore, DualStoreConfig, IpldReferences, IpldStore, MemoryStore,
-    StoreResult,
+    RawStore, StoreResult,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::io::AsyncRead;
@@ -66,10 +66,6 @@ where
         self.inner.put_bytes(reader).await
     }
 
-    async fn put_raw_block(&self, bytes: impl Into<Bytes> + Send) -> StoreResult<Cid> {
-        self.inner.put_raw_block(bytes).await
-    }
-
     async fn get_node<T>(&self, cid: &Cid) -> StoreResult<T>
     where
         T: DeserializeOwned + Send,
@@ -84,8 +80,8 @@ where
         self.inner.get_bytes(cid).await
     }
 
-    async fn get_raw_block(&self, cid: &Cid) -> StoreResult<Bytes> {
-        self.inner.get_raw_block(cid).await
+    async fn get_bytes_size(&self, cid: &Cid) -> StoreResult<u64> {
+        self.inner.get_bytes_size(cid).await
     }
 
     #[inline]
@@ -102,12 +98,25 @@ where
         self.inner.get_node_block_max_size()
     }
 
+    async fn get_block_count(&self) -> StoreResult<u64> {
+        self.inner.get_block_count().await
+    }
+}
+
+impl<S> RawStore for MemoryBufferStore<S>
+where
+    S: IpldStore + Sync,
+{
+    async fn put_raw_block(&self, bytes: impl Into<Bytes> + Send) -> StoreResult<Cid> {
+        self.inner.put_raw_block(bytes).await
+    }
+
+    async fn get_raw_block(&self, cid: &Cid) -> StoreResult<Bytes> {
+        self.inner.get_raw_block(cid).await
+    }
+
     #[inline]
     fn get_raw_block_max_size(&self) -> Option<u64> {
         self.inner.get_raw_block_max_size()
-    }
-
-    async fn get_block_count(&self) -> StoreResult<u64> {
-        self.inner.get_block_count().await
     }
 }

--- a/monoutils-store/Cargo.toml
+++ b/monoutils-store/Cargo.toml
@@ -19,6 +19,7 @@ async-stream.workspace = true
 bytes.workspace = true
 futures.workspace = true
 hex = "0.4.3"
+pretty-error-debug.workspace = true
 libipld = { workspace = true, features = ["serde-codec"] }
 lru = "0.12.3"
 serde = { workspace = true, features = ["derive"] }

--- a/monoutils-store/lib/error.rs
+++ b/monoutils-store/lib/error.rs
@@ -16,7 +16,7 @@ use super::Codec;
 pub type StoreResult<T> = Result<T, StoreError>;
 
 /// An error that occurred during a file system operation.
-#[derive(Debug, Error, PartialEq)]
+#[derive(pretty_error_debug::Debug, Error, PartialEq)]
 pub enum StoreError {
     /// The block was not found.
     #[error("Block not found: {0}")]
@@ -53,6 +53,10 @@ pub enum LayoutError {
     /// No leaf block found.
     #[error("No leaf block found")]
     NoLeafBlock,
+
+    /// Empty stream.
+    #[error("Empty stream")]
+    EmptyStream,
 }
 
 /// An error that can represent any error.

--- a/monoutils-store/lib/implementations/layouts/balanced.rs
+++ b/monoutils-store/lib/implementations/layouts/balanced.rs
@@ -38,4 +38,8 @@ impl Layout for BalancedDagLayout {
     ) -> StoreResult<Pin<Box<dyn AsyncRead + Send + Sync + 'a>>> {
         todo!() // TODO: To be implemented
     }
+
+    async fn get_size(&self, _cid: &Cid, _store: impl IpldStore + Send + Sync) -> StoreResult<u64> {
+        todo!() // TODO: To be implemented
+    }
 }

--- a/monoutils-store/lib/implementations/layouts/trickle.rs
+++ b/monoutils-store/lib/implementations/layouts/trickle.rs
@@ -35,4 +35,8 @@ impl Layout for TrickleDagLayout {
     ) -> StoreResult<Pin<Box<dyn AsyncRead + Send + Sync + 'a>>> {
         todo!() // TODO: To be implemented
     }
+
+    async fn get_size(&self, _cid: &Cid, _store: impl IpldStore + Send + Sync) -> StoreResult<u64> {
+        todo!() // TODO: To be implemented
+    }
 }

--- a/monoutils-store/lib/layout.rs
+++ b/monoutils-store/lib/layout.rs
@@ -33,6 +33,13 @@ pub trait Layout {
         cid: &Cid,
         store: impl IpldStore + Send + Sync + 'a,
     ) -> impl Future<Output = StoreResult<Pin<Box<dyn AsyncRead + Send + Sync + 'a>>>> + Send;
+
+    /// Returns the size of the underlying byte chunks associated with a given `Cid`.
+    fn get_size(
+        &self,
+        cid: &Cid,
+        store: impl IpldStore + Send + Sync,
+    ) -> impl Future<Output = StoreResult<u64>> + Send;
 }
 
 /// A trait that extends the `Layout` trait to allow for seeking.


### PR DESCRIPTION
- Split raw block operations into separate RawStore trait
- Change File::with_content to take AsyncRead instead of Into<Bytes>
- Make File::is_empty async and return FsResult
- Add get_bytes_size method to IpldStore trait
- Rename FastCDC to FastCDCChunker for clarity
- Rename GearCDC to GearCDCChunker for clarity
- Extracting raw block operations into a dedicated RawStore trait
- Making file operations more async-friendly and consistent
- Adding size tracking capabilities to store implementations
- Improving error handling and documentation
- Enhancing FastCDC chunker implementation with better docs and optimizations
