### PR TITLE
refactor(monofs): replace shutdown with flush in file operations

### DIFF
--- a/monofs/examples/file.rs
+++ b/monofs/examples/file.rs
@@ -45,10 +45,10 @@ async fn main() -> anyhow::Result<()> {
     let content = b"Hello, monofs!";
     let mut output_stream = file.get_output_stream();
     output_stream.write_all(content).await?;
-    output_stream.shutdown().await?;
+    output_stream.flush().await?;
+    drop(output_stream);
     println!("Wrote content to file");
 
-    drop(output_stream);
 
     // Read content from the file
     let input_stream = file.get_input_stream().await?;

--- a/monofs/examples/flatfs_monofs.rs
+++ b/monofs/examples/flatfs_monofs.rs
@@ -123,10 +123,8 @@ async fn perform_example_operations<S: IpldStore + Send + Sync + 'static>(
     output
         .write_all(b"# Documentation\n\nWelcome to the docs!")
         .await?;
-    output.shutdown().await?;
+    output.flush().await?;
     drop(output);
-
-    // output.flush().await?; // TODO
 
     let docs = root.find_mut("docs").await?.unwrap();
     if let Entity::Dir(ref mut docs_dir) = docs {
@@ -139,7 +137,7 @@ async fn perform_example_operations<S: IpldStore + Send + Sync + 'static>(
     output
         .write_all(b"{\n  \"version\": \"1.0.0\",\n  \"name\": \"flat-monofs\"\n}")
         .await?;
-    output.shutdown().await?;
+    output.flush().await?;
     drop(output);
 
     let configs = root.find_or_create("data/configs", false).await?;
@@ -153,7 +151,7 @@ async fn perform_example_operations<S: IpldStore + Send + Sync + 'static>(
     output
         .write_all(b"fn main() {\n    println!(\"Hello from flat-monofs!\");\n}")
         .await?;
-    output.shutdown().await?;
+    output.flush().await?;
     drop(output);
 
     let rust = root.find_or_create("projects/rust", false).await?;

--- a/monofs/lib/filesystem/dir/ops.rs
+++ b/monofs/lib/filesystem/dir/ops.rs
@@ -176,7 +176,7 @@ where
         path: impl AsRef<str>,
         file: bool,
     ) -> FsResult<&mut Entity<S>> {
-        tracing::info!("find_or_create: path: {:?}, file: {}", path.as_ref(), file);
+        tracing::trace!("find_or_create: path: {:?}, file: {}", path.as_ref(), file);
         let path = Utf8UnixPath::new(path.as_ref());
 
         if path.has_root() {
@@ -250,7 +250,7 @@ where
     /// Creates a file at the specified path.
     #[inline]
     pub async fn create_file(&mut self, path: impl AsRef<str>) -> FsResult<&mut File<S>> {
-        tracing::info!("create_file: path: {:?}", path.as_ref());
+        tracing::trace!("create_file: path: {:?}", path.as_ref());
         match self
             .create_entity(path, File::new(self.get_store().clone()))
             .await?
@@ -263,7 +263,7 @@ where
     /// Creates a directory at the specified path.
     #[inline]
     pub async fn create_dir(&mut self, path: impl AsRef<str>) -> FsResult<&mut Dir<S>> {
-        tracing::info!("create_dir: path: {:?}", path.as_ref());
+        tracing::trace!("create_dir: path: {:?}", path.as_ref());
         match self
             .create_entity(path, Dir::new(self.get_store().clone()))
             .await?
@@ -280,7 +280,7 @@ where
         path: impl AsRef<str>,
         target: impl AsRef<str>,
     ) -> FsResult<&mut SymPathLink<S>> {
-        tracing::info!(
+        tracing::trace!(
             "create_sympathlink: path: {:?}, target: {:?}",
             path.as_ref(),
             target.as_ref()
@@ -304,7 +304,7 @@ where
         path: impl AsRef<str>,
         cid: Cid,
     ) -> FsResult<&mut SymCidLink<S>> {
-        tracing::info!(
+        tracing::trace!(
             "create_symcidlink: path: {:?}, cid: {:?}",
             path.as_ref(),
             cid
@@ -342,7 +342,7 @@ where
     /// # }
     /// ```
     pub fn list(&self) -> impl Iterator<Item = Utf8UnixPathSegment> + '_ {
-        tracing::info!("list");
+        tracing::trace!("list");
         self.get_entries().map(|(k, _)| k.clone())
     }
 
@@ -369,7 +369,7 @@ where
     /// # }
     /// ```
     pub async fn copy(&mut self, source: impl AsRef<str>, target: impl AsRef<str>) -> FsResult<()> {
-        tracing::info!(
+        tracing::trace!(
             "copy: source: {:?}, target: {:?}",
             source.as_ref(),
             target.as_ref()
@@ -442,7 +442,7 @@ where
     /// # }
     /// ```
     pub async fn remove(&mut self, path: impl AsRef<str>) -> FsResult<()> {
-        tracing::info!("remove: path: {:?}", path.as_ref());
+        tracing::trace!("remove: path: {:?}", path.as_ref());
         let path = Utf8UnixPath::new(path.as_ref());
 
         if path.has_root() {
@@ -499,7 +499,7 @@ where
         old_path: impl AsRef<str>,
         new_path: impl AsRef<str>,
     ) -> FsResult<()> {
-        tracing::info!(
+        tracing::trace!(
             "rename: old_path: {:?}, new_path: {:?}",
             old_path.as_ref(),
             new_path.as_ref()

--- a/monofs/lib/server/nfs.rs
+++ b/monofs/lib/server/nfs.rs
@@ -675,7 +675,7 @@ where
                 }
 
                 // Finalize the write
-                output.shutdown().await.map_err(|e| {
+                output.flush().await.map_err(|e| {
                     tracing::error!("Failed to finalize write: {}", e);
                     nfsstat3::NFS3ERR_IO
                 })?;

--- a/monoutils-store/lib/implementations/stores/memstore.rs
+++ b/monoutils-store/lib/implementations/stores/memstore.rs
@@ -270,8 +270,6 @@ impl Default for MemoryStore {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use crate::DEFAULT_MAX_CHUNK_SIZE;
 
     use super::fixtures::TestNode;
@@ -309,7 +307,7 @@ mod tests {
             .map(|i| (i % 255) as u8)
             .collect();
 
-        let cid = store.put_bytes(Cursor::new(data.clone())).await?; // TODO: Hate this clone
+        let cid = store.put_bytes(data.as_slice()).await?;
 
         // Verify the size matches
         let size = store.get_bytes_size(&cid).await?;


### PR DESCRIPTION
- Replace FileOutputStream shutdown() with flush() for better semantics
- Reorder flush and drop operations in file examples
- Change logging level from info to trace for file operations
- Remove unnecessary data clone in memstore tests
