### PR TITLE
feat(monofs): create symbolic link to mfs_data_dir in mount directory and configurable mfsrun binary path

### DIFF
--- a/monofs/lib/config/default.rs
+++ b/monofs/lib/config/default.rs
@@ -10,3 +10,6 @@ pub const DEFAULT_HOST: &str = "127.0.0.1";
 
 /// The default NFS port number to use.
 pub const DEFAULT_NFS_PORT: u32 = 2049;
+
+/// The default path for the mfsrun binary.
+pub const DEFAULT_MFSRUN_BIN_PATH: &str = "./mfsrun";

--- a/monofs/lib/error.rs
+++ b/monofs/lib/error.rs
@@ -151,6 +151,16 @@ pub enum FsError {
     /// Supervisor error.
     #[error("Supervisor error: {0}")]
     SupervisorError(String),
+
+    /// mfsrun binary not found at specified location
+    #[error("mfsrun binary not found at {path} from {src}")]
+    MfsrunBinaryNotFound {
+        /// The path that was checked
+        path: String,
+
+        /// Where the path came from - either "environment variable" or "default path"
+        src: String,
+    },
 }
 
 /// An error that can represent any error.

--- a/monofs/lib/utils/env.rs
+++ b/monofs/lib/utils/env.rs
@@ -1,11 +1,8 @@
-//! Utility functions.
-
-pub mod env;
-pub mod path;
+//! Utility functions for working with environment variables.
 
 //--------------------------------------------------------------------------------------------------
-// Exports
+// constants
 //--------------------------------------------------------------------------------------------------
 
-pub use env::*;
-pub use path::*;
+/// Environment variable for the mfsrun binary path
+pub const MFSRUN_BIN_PATH_ENV_VAR: &str = "MFSRUN_BIN_PATH";

--- a/monofs/lib/utils/path.rs
+++ b/monofs/lib/utils/path.rs
@@ -1,8 +1,12 @@
 //! Path utilities.
 
+use std::path::PathBuf;
+
 use typed_path::Utf8UnixPath;
 
-use crate::{filesystem::Utf8UnixPathSegment, FsError, FsResult};
+use crate::{config::DEFAULT_MFSRUN_BIN_PATH, filesystem::Utf8UnixPathSegment, FsError, FsResult};
+
+use super::MFSRUN_BIN_PATH_ENV_VAR;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -52,6 +56,34 @@ pub fn split_last(path: &Utf8UnixPath) -> FsResult<(Option<&Utf8UnixPath>, Utf8U
         .and_then(|p| (!p.as_str().is_empty()).then_some(p));
 
     Ok((parent, filename))
+}
+
+/// Resolves the path to the mfsrun binary, checking both environment variable and default locations.
+///
+/// First checks the environment variable specified by MFSRUN_BIN_PATH_ENV_VAR.
+/// If that's not set, falls back to DEFAULT_MFSRUN_BIN_PATH.
+/// Returns an error if the binary is not found at the resolved location.
+pub fn resolve_mfsrun_bin_path() -> FsResult<PathBuf> {
+    const MFSRUN_ENV_SOURCE: &str = "environment variable";
+    const MFSRUN_DEFAULT_SOURCE: &str = "default path";
+
+    let (path, source) = std::env::var(MFSRUN_BIN_PATH_ENV_VAR)
+        .map(|p| (PathBuf::from(p), MFSRUN_ENV_SOURCE))
+        .unwrap_or_else(|_| {
+            (
+                PathBuf::from(DEFAULT_MFSRUN_BIN_PATH),
+                MFSRUN_DEFAULT_SOURCE,
+            )
+        });
+
+    if !path.exists() {
+        return Err(FsError::MfsrunBinaryNotFound {
+            path: path.to_string_lossy().to_string(),
+            src: source.to_string(),
+        });
+    }
+
+    Ok(path)
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Create symbolic link from mount directory to mfs_data_dir
- Add symlink creation during filesystem initialization
- Ensure direct access to data directory from mount point
- Add DEFAULT_MFSRUN_BIN_PATH constant for default binary location
- Add MFSRUN_BIN_PATH_ENV_VAR for configuring binary path via environment
- Implement resolve_mfsrun_bin_path() to locate binary
- Add MfsrunBinaryNotFound error for missing binary
