### PR TITLE
refactor(store): rename block size methods and adjust defaults

### DIFF
--- a/monofs/examples/flatfs_store.rs
+++ b/monofs/examples/flatfs_store.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
         println!("    - {:?}", codec);
     }
 
-    if let Some(max_size) = store.get_node_block_max_size().await? {
+    if let Some(max_size) = store.get_max_node_block_size().await? {
         println!("  Max node block size: {} bytes", max_size);
     }
 

--- a/monofs/lib/store/membufferstore.rs
+++ b/monofs/lib/store/membufferstore.rs
@@ -88,8 +88,8 @@ where
         self.inner.get_supported_codecs().await
     }
 
-    async fn get_node_block_max_size(&self) -> StoreResult<Option<u64>> {
-        self.inner.get_node_block_max_size().await
+    async fn get_max_node_block_size(&self) -> StoreResult<Option<u64>> {
+        self.inner.get_max_node_block_size().await
     }
 
     async fn get_block_count(&self) -> StoreResult<u64> {
@@ -110,7 +110,7 @@ where
         self.inner.get_raw_block(cid).await
     }
 
-    async fn get_raw_block_max_size(&self) -> StoreResult<Option<u64>> {
-        self.inner.get_raw_block_max_size().await
+    async fn get_max_raw_block_size(&self) -> StoreResult<Option<u64>> {
+        self.inner.get_max_raw_block_size().await
     }
 }

--- a/monoutils-store/lib/constants.rs
+++ b/monoutils-store/lib/constants.rs
@@ -2,14 +2,17 @@
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// The default desired chunk size is 4 KiB.
-pub const DEFAULT_DESIRED_CHUNK_SIZE: u64 = 4 * 1024;
+/// The default desired chunk size is 128 KiB.
+pub const DEFAULT_DESIRED_CHUNK_SIZE: u64 = 128 * 1024;
 
-/// The default minimum chunk size is 2 KiB.
-pub const DEFAULT_MIN_CHUNK_SIZE: u64 = 2 * 1024;
+/// The default minimum chunk size is 32 KiB.
+pub const DEFAULT_MIN_CHUNK_SIZE: u64 = 32 * 1024;
 
-/// The default maximum chunk size is 64 KiB.
-pub const DEFAULT_MAX_CHUNK_SIZE: u64 = 64 * 1024;
+/// The default maximum chunk size is 512 KiB.
+pub const DEFAULT_MAX_CHUNK_SIZE: u64 = 512 * 1024;
+
+/// The default maximum node block size is 1 MiB.
+pub const DEFAULT_MAX_NODE_BLOCK_SIZE: u64 = 1 * 1024 * 1024;
 
 /// The gear table is used to generate the rolling hash mask.
 #[rustfmt::skip]

--- a/monoutils-store/lib/implementations/chunkers/fastcdc.rs
+++ b/monoutils-store/lib/implementations/chunkers/fastcdc.rs
@@ -5,11 +5,9 @@ use futures::stream::BoxStream;
 use std::pin::pin;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::{Chunker, StoreError, StoreResult};
-
-use super::{
-    constants::DEFAULT_MAX_CHUNK_SIZE, DEFAULT_DESIRED_CHUNK_SIZE, DEFAULT_GEAR_TABLE,
-    DEFAULT_MIN_CHUNK_SIZE,
+use crate::{
+    Chunker, StoreError, StoreResult, DEFAULT_DESIRED_CHUNK_SIZE, DEFAULT_GEAR_TABLE,
+    DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MIN_CHUNK_SIZE,
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/monoutils-store/lib/implementations/chunkers/fixed.rs
+++ b/monoutils-store/lib/implementations/chunkers/fixed.rs
@@ -6,9 +6,7 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::{Chunker, StoreError, StoreResult};
-
-use super::constants::DEFAULT_MAX_CHUNK_SIZE;
+use crate::{Chunker, StoreError, StoreResult, DEFAULT_MAX_CHUNK_SIZE};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/monoutils-store/lib/implementations/chunkers/gearcdc.rs
+++ b/monoutils-store/lib/implementations/chunkers/gearcdc.rs
@@ -6,9 +6,7 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::{Chunker, StoreError, StoreResult};
-
-use super::{DEFAULT_DESIRED_CHUNK_SIZE, DEFAULT_GEAR_TABLE};
+use crate::{Chunker, StoreError, StoreResult, DEFAULT_DESIRED_CHUNK_SIZE, DEFAULT_GEAR_TABLE};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/monoutils-store/lib/implementations/chunkers/mod.rs
+++ b/monoutils-store/lib/implementations/chunkers/mod.rs
@@ -1,4 +1,3 @@
-mod constants;
 mod fixed;
 mod fastcdc;
 mod gearcdc;
@@ -7,7 +6,6 @@ mod gearcdc;
 // Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use constants::*;
 pub use fixed::*;
 pub use fastcdc::*;
 pub use gearcdc::*;

--- a/monoutils-store/lib/implementations/stores/dualstore.rs
+++ b/monoutils-store/lib/implementations/stores/dualstore.rs
@@ -214,9 +214,9 @@ where
         codecs
     }
 
-    async fn get_node_block_max_size(&self) -> StoreResult<Option<u64>> {
-        let max_size_a = self.store_a.get_node_block_max_size().await?;
-        let max_size_b = self.store_b.get_node_block_max_size().await?;
+    async fn get_max_node_block_size(&self) -> StoreResult<Option<u64>> {
+        let max_size_a = self.store_a.get_max_node_block_size().await?;
+        let max_size_b = self.store_b.get_max_node_block_size().await?;
         Ok(max_size_a.max(max_size_b))
     }
 
@@ -250,9 +250,9 @@ where
         }
     }
 
-    async fn get_raw_block_max_size(&self) -> StoreResult<Option<u64>> {
-        let max_size_a = self.store_a.get_raw_block_max_size().await?;
-        let max_size_b = self.store_b.get_raw_block_max_size().await?;
+    async fn get_max_raw_block_size(&self) -> StoreResult<Option<u64>> {
+        let max_size_a = self.store_a.get_max_raw_block_size().await?;
+        let max_size_b = self.store_b.get_max_raw_block_size().await?;
         Ok(max_size_a.max(max_size_b))
     }
 }

--- a/monoutils-store/lib/lib.rs
+++ b/monoutils-store/lib/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::module_inception)]
 
 mod chunker;
+mod constants;
 mod error;
 mod implementations;
 mod layout;
@@ -18,6 +19,7 @@ pub mod utils;
 //--------------------------------------------------------------------------------------------------
 
 pub use chunker::*;
+pub use constants::*;
 pub use error::*;
 pub use implementations::*;
 pub use layout::*;

--- a/monoutils-store/lib/store.rs
+++ b/monoutils-store/lib/store.rs
@@ -85,10 +85,7 @@ pub trait IpldStore: RawStore + Clone {
     /// ## Errors
     ///
     /// If the block is not found, `StoreError::BlockNotFound` error is returned.
-    async fn get_bytes(
-        &self,
-        cid: &Cid,
-    ) -> StoreResult<Pin<Box<dyn AsyncRead + Send>>>;
+    async fn get_bytes(&self, cid: &Cid) -> StoreResult<Pin<Box<dyn AsyncRead + Send>>>;
 
     /// Gets the size of all the blocks associated with the given `Cid` in bytes.
     async fn get_bytes_size(&self, cid: &Cid) -> StoreResult<u64>;
@@ -101,7 +98,7 @@ pub trait IpldStore: RawStore + Clone {
 
     /// Returns the allowed maximum block size for IPLD and merkle nodes.
     /// If there is no limit, `None` is returned.
-    async fn get_node_block_max_size(&self) -> StoreResult<Option<u64>>;
+    async fn get_max_node_block_size(&self) -> StoreResult<Option<u64>>;
 
     /// Checks if the store is empty.
     async fn is_empty(&self) -> StoreResult<bool> {
@@ -139,6 +136,12 @@ pub trait RawStore: Clone {
     /// Tries to save `bytes` as a single block to the store. Unlike [`IpldStore::put_bytes`], this
     /// method does not chunk the data and does not create intermediate merkle nodes.
     ///
+    /// ## Arguments
+    ///
+    /// - `bytes`: The bytes to save.
+    /// - `is_node`: If true, the block is considered a node block and the size is checked against
+    ///   the node block size.
+    ///
     /// ## Important
     ///
     /// This is a low-level API intended for code implementing an [`IpldStore`].
@@ -168,7 +171,7 @@ pub trait RawStore: Clone {
     async fn get_raw_block(&self, cid: &Cid) -> StoreResult<Bytes>;
 
     /// Returns the allowed maximum block size for raw bytes. If there is no limit, `None` is returned.
-    async fn get_raw_block_max_size(&self) -> StoreResult<Option<u64>>;
+    async fn get_max_raw_block_size(&self) -> StoreResult<Option<u64>>;
 }
 
 /// Helper extension to the `IpldStore` trait.


### PR DESCRIPTION
- Increased default chunk sizes:
  - Desired: 4KB -> 128KB
  - Min: 2KB -> 32KB
  - Max: 64KB -> 512KB
- Added DEFAULT_MAX_NODE_BLOCK_SIZE constant (1MB)
- Moved constants from chunkers to root level
- Updated stores to use new node block size limit
- Renamed methods for consistency:
  - get_node_block_max_size() -> get_max_node_block_size()
  - get_raw_block_max_size() -> get_max_raw_block_size()
