### PR TITLE
feat(store): implement garbage collection for MemoryStore

### DIFF
--- a/.todo.md
+++ b/.todo.md
@@ -14,12 +14,28 @@
   - [x] `IpldStore::get_cid_size(cid: &Cid) -> Result<u64, Error>`?
   - [x] `Layout::get_cid_size(cid: &Cid) -> Result<u64, Error>`?
 
+- [ ] `checkpoint` does not have to re-load the entity from the store.
+
+  - [ ] We can take an efficient shortcut by modifying the initial_load_cid in-place during store.
+  - [ ] Introduce an internal `store_in_place` method?
+
 ## monoutils-store
 
-- [ ] Implement a content-defined chunker that uses Gear Hashing.
+- [ ] Consider other store implementations optimized for write or read efficiency
 
-  - [ ] FastCDC?
-  - [ ] Make it the default chunker for stores.
+  - [ ] `RocksDbStore` - backed by RocksDB.
+  - [ ] `PackedFsStore` - writes multiple blocks to a single file.
+
+- [ ] Support compression in `FlatFsStore` for better storage efficiency.
+
+  - [ ] Compression option for block and packed files.
+  - [ ] GZIP with flate2-rs.
+
+- [x] Implement a content-defined chunker that uses Gear Hashing.
+
+  - [x] FastCDC
+  - [x] GearCDC
+  - [x] Make it the default chunker for stores.
 
 - [ ] Implement `BalancedDagLayout` and make it the default layout for stores.
 
@@ -29,30 +45,25 @@
   - [ ] `MemoryStore`
   - [ ] A stored `node` or `bytes` should be deleted when the last reference is dropped.
 
-- [ ] Implement seeking for writes in `IpldStoreSeekable`
-
-  - [ ] Figure out how Chunker and Layout can support seeking writes.
-  - [ ] Introduce `put_bytes_seekable`.
-
 - [ ] `FlatFsStore` should support refcounting.
 
 - [ ] `bytes` and `raw_blocks` should support refcounting too.
-
-- [ ] Must be able to break large nodes into smaller ones.
-
-  - [ ] Therefore there is no need to have different max sizes for `bytes` and `node`.
 
 ## monocore
 
 - [x] Fix copy and remove permission issues on Linux.
 
-- [ ] Use sqlitedb for maintaining running services state.
+- [x] Use sqlitedb for maintaining running services state.
 
 - [ ] Treating microvm management like a package manager.
 
-  - [ ] Store service rootfs, state, logs locally in a .mc directory kind of like ./node_modules.
-  - [ ] Store reference rootfses (oci & monofs) in home_dir with a special store that links to them from forked rootfses.
-
 - [ ] Support multiple registries.
-  - [x] Use `Reference` type for image_ref where it makes sense: https://docs.rs/oci-spec/0.7.1/oci_spec/distribution/struct.Reference.html
-  - [ ] Qualify image names fully where needed. <registry>/<repo>:<tag>
+
+  - [ ] Docker
+  - [ ] Github
+  - [ ] Quay
+  - [ ] Sandboxes
+
+- [x] Use `Reference` type for image_ref where it makes sense: https://docs.rs/oci-spec/0.7.1/oci_spec/distribution/struct.Reference.html
+
+- [x] Qualify image names fully where needed. <registry>/<repo>:<tag>

--- a/monoutils-store/lib/implementations/layouts/flat.rs
+++ b/monoutils-store/lib/implementations/layouts/flat.rs
@@ -260,9 +260,7 @@ impl Layout for FlatLayout {
             let mut children = Vec::new();
             while let Some(Ok(chunk)) = stream.next().await {
                 let len = chunk.len();
-                tracing::trace!("organizing by putting raw block: {:?}", len);
                 let cid = store.put_raw_block(chunk).await?;
-                tracing::trace!("successfully put raw block");
                 children.push((cid, len));
                 yield cid;
             }


### PR DESCRIPTION
- Add reference counting for stored blocks
- Implement garbage_collect method to remove unreferenced blocks
- Add recursive cleanup of dependencies when blocks are removed
- Add comprehensive tests for garbage collection scenarios
- Improve documentation of IpldStore trait methods
- Add Unknown variant to Codec enum

