### PR TITLE
refactor(store): improve DualStore configuration and documentation

### DIFF
--- a/monofs/lib/store/flatfsstore.rs
+++ b/monofs/lib/store/flatfsstore.rs
@@ -299,7 +299,7 @@ where
         }
 
         // Create CID and store the block
-        let cid = monoutils_store::make_cid(Codec::DagCbor, &bytes);
+        let cid = monoutils_store::generate_cid(Codec::DagCbor, &bytes);
         let block_path = self.get_block_path(&cid);
 
         if !block_path.exists() {
@@ -570,7 +570,7 @@ where
             }
         }
 
-        let cid = monoutils_store::make_cid(Codec::Raw, bytes.as_ref());
+        let cid = monoutils_store::generate_cid(Codec::Raw, bytes.as_ref());
         let block_path = self.get_block_path(&cid);
 
         if !block_path.exists() {

--- a/monofs/lib/store/layeredstore.rs
+++ b/monofs/lib/store/layeredstore.rs
@@ -1,0 +1,120 @@
+use std::{collections::HashSet, pin::Pin};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use monoutils_store::{
+    ipld::cid::Cid, Codec, DualStore, DualStoreConfig, IpldReferences, IpldStore, MemoryStore,
+    RawStore, StoreResult,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::io::AsyncRead;
+
+//--------------------------------------------------------------------------------------------------
+// Types: LayeredStore
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LayeredStore<S>
+where
+    S: IpldStore,
+{
+    inner: LayeredStoreInner<S>,
+}
+
+struct LayeredStoreInner<S>
+where
+    S: IpldStore,
+{
+    write_store: S,
+    base_store: S,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: MemoryBufferStore
+//--------------------------------------------------------------------------------------------------
+
+impl<S> MemoryBufferStore<S>
+where
+    S: IpldStore,
+{
+    /// Creates a new `MemoryBufferStore` with the given backup store.
+    pub fn new(backup_store: S) -> Self {
+        Self {
+            inner: DualStore::new(
+                MemoryStore::default(),
+                backup_store,
+                DualStoreConfig::default(),
+            ),
+        }
+    }
+}
+
+// //--------------------------------------------------------------------------------------------------
+// // Trait Implementations
+// //--------------------------------------------------------------------------------------------------
+
+// #[async_trait]
+// impl<S> IpldStore for MemoryBufferStore<S>
+// where
+//     S: IpldStore + Sync,
+// {
+//     async fn put_node<T>(&self, data: &T) -> StoreResult<Cid>
+//     where
+//         T: Serialize + IpldReferences + Sync,
+//     {
+//         self.inner.put_node(data).await
+//     }
+
+//     async fn put_bytes(&self, reader: impl AsyncRead + Send + Sync) -> StoreResult<Cid> {
+//         self.inner.put_bytes(reader).await
+//     }
+
+//     async fn get_node<T>(&self, cid: &Cid) -> StoreResult<T>
+//     where
+//         T: DeserializeOwned + Send,
+//     {
+//         self.inner.get_node(cid).await
+//     }
+
+//     async fn get_bytes(&self, cid: &Cid) -> StoreResult<Pin<Box<dyn AsyncRead + Send>>> {
+//         self.inner.get_bytes(cid).await
+//     }
+
+//     async fn get_bytes_size(&self, cid: &Cid) -> StoreResult<u64> {
+//         self.inner.get_bytes_size(cid).await
+//     }
+
+//     async fn has(&self, cid: &Cid) -> bool {
+//         self.inner.has(cid).await
+//     }
+
+//     async fn get_supported_codecs(&self) -> HashSet<Codec> {
+//         self.inner.get_supported_codecs().await
+//     }
+
+//     async fn get_max_node_block_size(&self) -> StoreResult<Option<u64>> {
+//         self.inner.get_max_node_block_size().await
+//     }
+
+//     async fn get_block_count(&self) -> StoreResult<u64> {
+//         self.inner.get_block_count().await
+//     }
+// }
+
+// #[async_trait]
+// impl<S> RawStore for MemoryBufferStore<S>
+// where
+//     S: IpldStore + Sync,
+// {
+//     async fn put_raw_block(&self, bytes: impl Into<Bytes> + Send) -> StoreResult<Cid> {
+//         self.inner.put_raw_block(bytes).await
+//     }
+
+//     async fn get_raw_block(&self, cid: &Cid) -> StoreResult<Bytes> {
+//         self.inner.get_raw_block(cid).await
+//     }
+
+//     async fn get_max_raw_block_size(&self) -> StoreResult<Option<u64>> {
+//         self.inner.get_max_raw_block_size().await
+//     }
+// }

--- a/monoutils-store/lib/store.rs
+++ b/monoutils-store/lib/store.rs
@@ -60,7 +60,7 @@ pub trait IpldStore: RawStore + Clone {
     ///
     /// ## Arguments
     ///
-    /// * `data` - The object to store
+    /// * `node` - The object to store
     ///
     /// ## Returns
     ///
@@ -69,7 +69,7 @@ pub trait IpldStore: RawStore + Clone {
     /// ## Errors
     ///
     /// Returns `StoreError::NodeBlockTooLarge` if the serialized data exceeds the store's maximum node block size.
-    async fn put_node<T>(&self, data: &T) -> StoreResult<Cid>
+    async fn put_node<T>(&self, node: &T) -> StoreResult<Cid>
     where
         T: Serialize + IpldReferences + Sync;
 
@@ -321,6 +321,15 @@ pub trait StoreSwitchable {
     fn change_store<U: IpldStore>(self, new_store: U) -> Self::WithStore<U>;
 }
 
+/// A trait for stores that can be configured.
+pub trait StoreConfig {
+    /// The type of the configuration.
+    type Config: Serialize + DeserializeOwned;
+
+    /// Returns the configuration for the store.
+    fn get_config(&self) -> Self::Config;
+}
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -334,7 +343,7 @@ impl TryFrom<u64> for Codec {
             0x71 => Ok(Codec::DagCbor),
             0x0129 => Ok(Codec::DagJson),
             0x70 => Ok(Codec::DagPb),
-            _ => Err(StoreError::UnsupportedCodec(value)),
+            v => Ok(Codec::Unknown(v)),
         }
     }
 }

--- a/monoutils-store/lib/utils.rs
+++ b/monoutils-store/lib/utils.rs
@@ -5,7 +5,6 @@ use multihash_codetable::{Code, MultihashDigest};
 
 use crate::Codec;
 
-
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -13,7 +12,7 @@ use crate::Codec;
 /// Hashes data with [Blake3-256][blake] and returns a new [`Cid`] to it.
 ///
 /// [blake]: https://en.wikipedia.org/wiki/BLAKE_(hash_function)
-pub fn make_cid(codec: Codec, data: &[u8]) -> Cid {
+pub fn generate_cid(codec: Codec, data: &[u8]) -> Cid {
     let digest = Code::Blake3_256.digest(data);
     Cid::new_v1(codec.into(), digest)
 }


### PR DESCRIPTION
- Improved DualStore configuration with separate read_from and write_to options
- Added comprehensive documentation and examples for DualStore
- Added extensive test coverage for DualStore operations
- Renamed data parameter to node in IpldStore trait for consistency
- Added StoreConfig trait for configurable stores
- Updated Codec enum to handle unknown values
- Renamed make_cid to generate_cid for better semantic clarity
