### PR TITLE
refactor(store): make FlatFsStore refcounting optional and improve MemoryStore APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror 1.0.65",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1147,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -1778,6 +1799,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "gag",
  "getset",
  "hex",
  "intaglio",
@@ -1785,6 +1807,7 @@ dependencies = [
  "monoutils-store",
  "nfsserve",
  "nix",
+ "os_pipe",
  "pin-project-lite",
  "pretty-error-debug",
  "serde",
@@ -2153,6 +2176,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "overload"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,12 +1015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,11 +1223,6 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
@@ -1648,15 +1637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.0",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1797,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "typed-builder",
  "typed-path",
 ]
 
@@ -1861,7 +1842,6 @@ dependencies = [
  "futures",
  "hex",
  "ipld-core",
- "lru",
  "monoutils",
  "multihash",
  "multihash-codetable",
@@ -1873,6 +1853,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "typed-builder",
 ]
 
 [[package]]

--- a/monocore/lib/oci/implementations/docker.rs
+++ b/monocore/lib/oci/implementations/docker.rs
@@ -509,7 +509,7 @@ mod tests {
     use tokio::test;
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to pull an image"]
     async fn test_docker_pull_image() -> anyhow::Result<()> {
         let (client, temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
         let repository = "library/alpine";
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to fetch image index"]
     async fn test_docker_fetch_index() -> anyhow::Result<()> {
         let (client, _temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
         let repository = "library/alpine";
@@ -615,7 +615,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to fetch image manifest"]
     async fn test_docker_fetch_manifest() -> anyhow::Result<()> {
         let (client, _temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
         let repository = "library/alpine";
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to fetch image config"]
     async fn test_docker_fetch_config() -> anyhow::Result<()> {
         let (client, _temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
         let repository = "library/alpine";
@@ -703,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to fetch image blob"]
     async fn test_docker_fetch_image_blob() -> anyhow::Result<()> {
         let (client, temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
         let repository = "library/alpine";
@@ -747,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "makes network requests to Docker registry to get authentication credentials"]
     async fn test_docker_get_access_credentials() -> anyhow::Result<()> {
         let (client, _temp_download_dir, _temp_db_dir) = helper::setup_test_client().await;
 

--- a/monofs/Cargo.toml
+++ b/monofs/Cargo.toml
@@ -52,3 +52,5 @@ typed-builder.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true
+gag = "1.0"
+os_pipe = "1.1"

--- a/monofs/Cargo.toml
+++ b/monofs/Cargo.toml
@@ -48,6 +48,7 @@ clap.workspace = true
 pin-project-lite = "0.2.15"
 sqlx.workspace = true
 nix.workspace = true
+typed-builder.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/monofs/examples/flatfs_monofs.rs
+++ b/monofs/examples/flatfs_monofs.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use clap::Parser;
 use monofs::{
     filesystem::{Dir, Entity, File},
-    store::FlatFsStoreDefault,
+    store::FlatFsStore,
 };
 use monoutils_store::{ipld::cid::Cid, IpldStore, Storable};
 use std::future::Future;
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
     println!("\nUsing filesystem directory: {}\n", args.path.display());
 
     // Initialize the store with blocks directory
-    let store = FlatFsStoreDefault::new(blocks_path.to_str().unwrap());
+    let store = FlatFsStore::new(blocks_path);
 
     // Path to head CID file
     let head_path = args.path.join("head");

--- a/monofs/examples/flatfs_store.rs
+++ b/monofs/examples/flatfs_store.rs
@@ -21,7 +21,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use monofs::store::FlatFsStoreDefault;
+use monofs::store::FlatFsStore;
 use monoutils_store::ipld::cid::Cid;
 use monoutils_store::{IpldReferences, IpldStore};
 use serde::{Deserialize, Serialize};
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     println!("\nUsing store directory: {}\n", args.path.display());
 
     // Initialize the store with blocks directory
-    let store = FlatFsStoreDefault::new(blocks_path.to_str().unwrap());
+    let store = FlatFsStore::new(blocks_path);
 
     // Path to head CID file
     let head_path = args.path.join("head");

--- a/monofs/lib/filesystem/dir.rs
+++ b/monofs/lib/filesystem/dir.rs
@@ -37,7 +37,7 @@ pub const DIR_TYPE_TAG: &str = "monofs.dir";
 /// Entities in `monofs` are designed to be immutable and clone-on-write meaning writes create
 /// forks of the entity.
 #[derive(Clone)]
-pub struct Dir<S>
+pub struct  Dir<S>
 where
     S: IpldStore,
 {

--- a/monofs/lib/filesystem/dir/ops.rs
+++ b/monofs/lib/filesystem/dir/ops.rs
@@ -1079,6 +1079,7 @@ mod tests {
         // Create a complex rename scenario and verify store state
         dir.find_or_create("state_test/source/file.txt", true)
             .await?;
+
         // Create target directory first
         dir.find_or_create("state_test/target", false).await?;
 

--- a/monofs/lib/server/server.rs
+++ b/monofs/lib/server/server.rs
@@ -2,7 +2,7 @@ use getset::Getters;
 use nfsserve::tcp::{NFSTcp, NFSTcpListener};
 use std::path::PathBuf;
 
-use crate::store::FlatFsStoreDefault;
+use crate::store::FlatFsStore;
 
 use super::MonofsNFS;
 
@@ -34,7 +34,7 @@ impl MonofsServer {
     /// Starts the NFS server and blocks until it is shut down.
     pub async fn start(&self) -> anyhow::Result<()> {
         // Create the store and NFS filesystem
-        let store = FlatFsStoreDefault::new(&self.store_dir.to_string_lossy());
+        let store = FlatFsStore::new(&self.store_dir);
         let fs = MonofsNFS::new(store);
 
         // Create and start the NFS listener

--- a/monofs/lib/store/flatfsstore.rs
+++ b/monofs/lib/store/flatfsstore.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::{collections::HashSet, path::PathBuf, pin::Pin};
 
 use async_trait::async_trait;
@@ -111,11 +112,15 @@ where
 {
     #[builder(setter(into))]
     path: PathBuf,
+
     dir_levels: DirLevels,
-    #[builder(default = C::default())]
-    chunker: C,
-    #[builder(default = L::default())]
-    layout: L,
+
+    #[builder(default = Arc::new(C::default()))]
+    chunker: Arc<C>,
+
+    #[builder(default = Arc::new(L::default()))]
+    layout: Arc<L>,
+
     #[builder(default = true)]
     enable_refcount: bool,
 }
@@ -890,18 +895,24 @@ mod tests {
 
         // ======================== Tree Structure ========================
         //
-        //             root[value: 5, rc: 0]
+        //             root[val: 5, rc: 0]
         //                 /            \
         //                /              \
         //               /                \
-        //  middle1[value: 3, rc: 1]      middle2[value: 4, rc: 1]
-        //        /           \                /              \
-        //       /             \              /                \
-        //      /               \            /                  \
-        //  leaf1[value: 1, rc: 1]   leaf2[value: 2, rc: 2]      \
+        //              /                  \
+        //             /                    \
+        // middle1[val: 3, rc: 1]      middle2[val: 4, rc: 1]
+        //        /            \                /          \
+        //       /              \              /            \
+        //      /                \            /              \
+        //     /                  \          /                \
+        //    /                    \        /                  \
+        // leaf1[val: 1, rc: 1]  leaf2[val: 2, rc: 2]           \
+        //     |                           |                     \
         //     |                           |                      \
         //     |                           |                       \
-        //  data1[rc: 1]             data2[rc: 1]            data3[rc: 1]
+        //     |                           |                        \
+        // data1[rc: 1]             data2[rc: 1]             data3[rc: 1]
         //
         // ===============================================================
 

--- a/monofs/lib/utils/dir.rs
+++ b/monofs/lib/utils/dir.rs
@@ -1,0 +1,347 @@
+//! Directory utility functions for monofs.
+//!
+//! This module provides utilities for working with directories in the monofs filesystem,
+//! including functions for displaying directory structures in a tree-like format.
+
+use async_recursion::async_recursion;
+use monoutils_store::IpldStore;
+
+use crate::{filesystem::Dir, FsResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Number of spaces used for each level of indentation
+const INDENT_SIZE: usize = 4;
+
+/// Vertical line character for tree drawing
+const VERTICAL: &str = "│";
+
+/// Branch character for tree drawing (non-last items)
+const BRANCH: &str = "├──";
+
+/// Leaf character for tree drawing (last items)
+const LEAF: &str = "└──";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Prints a visual tree representation of the directory structure.
+///
+/// This function displays the entire directory hierarchy using traditional tree-drawing characters
+/// and visual indicators for different types of entries. The output follows common filesystem
+/// conventions for ordering:
+///
+/// 1. Directories first (with 📁 icon and trailing slash)
+/// 2. Files next (with 📄 icon and size in bytes)
+/// 3. Symbolic links last (with 🔗 icon)
+///
+/// Within each category (directories/files/symlinks), entries are sorted alphabetically.
+///
+/// ## Examples
+///
+/// ```
+/// use monofs::filesystem::Dir;
+/// use monoutils_store::MemoryStore;
+///
+/// # #[tokio::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// let store = MemoryStore::default();
+/// let mut dir = Dir::new(store.clone());
+///
+/// // Create some test files and directories
+/// dir.find_or_create("docs/README.md", true).await?;
+/// dir.find_or_create("src/main.rs", true).await?;
+/// dir.find_or_create("src/lib/mod.rs", true).await?;
+///
+/// // Print the directory tree
+/// print_dir_tree(&dir).await?;
+/// // Output will look like:
+/// // ├── 📁 docs/
+/// // │   └── 📄 README.md (0 bytes)
+/// // └── 📁 src/
+/// //     ├── 📁 lib/
+/// //     │   └── 📄 mod.rs (0 bytes)
+/// //     └── 📄 main.rs (0 bytes)
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Notes
+///
+/// - Uses traditional tree-drawing characters (├──, └──, │)
+/// - File entries include their size in bytes
+/// - Directory entries have a trailing slash
+/// - Symbolic links are marked with a special icon
+/// - Entries are sorted by type first, then alphabetically
+pub async fn print_dir_tree<S>(dir: &Dir<S>) -> FsResult<()>
+where
+    S: IpldStore + Send + Sync,
+{
+    print_dir_tree_with_depth(dir, vec![]).await
+}
+
+/// Internal helper function that implements the recursive tree printing logic.
+///
+/// This function handles the actual work of printing the tree structure using box-drawing
+/// characters. It tracks the prefix for each line to properly draw the tree structure.
+#[async_recursion]
+async fn print_dir_tree_with_depth<S>(dir: &Dir<S>, mut prefix_parts: Vec<bool>) -> FsResult<()>
+where
+    S: IpldStore + Send + Sync,
+{
+    // Collect entries and resolve them first
+    let mut entries: Vec<_> = Vec::new();
+    for (name, link) in dir.get_entries() {
+        let entity = link.resolve_entity(dir.get_store().clone()).await?;
+        entries.push((name, link, entity));
+    }
+
+    // Sort entries: directories first, then alphabetically within each type
+    entries.sort_by(|(name_a, _, entity_a), (name_b, _, entity_b)| {
+        match (entity_a, entity_b) {
+            // Both are directories - sort by name
+            (crate::filesystem::Entity::Dir(_), crate::filesystem::Entity::Dir(_)) => {
+                name_a.cmp(name_b)
+            }
+            // A is directory, B is not - A comes first
+            (crate::filesystem::Entity::Dir(_), _) => std::cmp::Ordering::Less,
+            // B is directory, A is not - B comes first
+            (_, crate::filesystem::Entity::Dir(_)) => std::cmp::Ordering::Greater,
+            // Neither is a directory - sort by name
+            _ => name_a.cmp(name_b),
+        }
+    });
+
+    let total = entries.len();
+
+    for (idx, (name, _, entity)) in entries.into_iter().enumerate() {
+        let is_last = idx == total - 1;
+        let prefix = build_prefix(&prefix_parts);
+        let connector = if is_last { LEAF } else { BRANCH };
+
+        match entity {
+            crate::filesystem::Entity::Dir(subdir) => {
+                println!("{}{} 📁 {}/", prefix, connector, name);
+                prefix_parts.push(!is_last);
+                print_dir_tree_with_depth(&subdir, prefix_parts.clone()).await?;
+                prefix_parts.pop();
+            }
+            crate::filesystem::Entity::File(file) => {
+                let size = file.get_size().await?;
+                println!("{}{} 📄 {} ({} bytes)", prefix, connector, name, size);
+            }
+            _ => println!("{}{} 🔗 {}", prefix, connector, name),
+        }
+    }
+
+    Ok(())
+}
+
+/// Builds the prefix string for a tree line based on the parent levels.
+///
+/// This helper function creates the proper indentation and vertical lines
+/// for each level of the tree.
+fn build_prefix(parts: &[bool]) -> String {
+    parts
+        .iter()
+        .map(|&has_sibling| {
+            if has_sibling {
+                format!("{}{}", VERTICAL, " ".repeat(INDENT_SIZE - 1))
+            } else {
+                " ".repeat(INDENT_SIZE)
+            }
+        })
+        .collect()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use monoutils_store::MemoryStore;
+    use tokio::io::AsyncWriteExt;
+
+    use crate::filesystem::File;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_print_dir_tree_empty_directory() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let dir = Dir::new(store);
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        assert_eq!(output, ""); // Empty directory should produce no output
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_single_file() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a file with some content
+        let mut file = File::new(store);
+        {
+            let mut output = file.get_output_stream();
+            output.write_all(b"test content").await?;
+            output.flush().await?;
+            drop(output);
+        }
+        dir.put_adapted_file("test.txt", file).await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        assert_eq!(output, "└── 📄 test.txt (12 bytes)\n");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_nested_structure() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a nested directory structure with mixed order
+        dir.find_or_create("src/main.rs", true).await?;
+        dir.find_or_create("docs/README.md", true).await?;
+        dir.find_or_create("src/lib/mod.rs", true).await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 docs/
+│   └── 📄 README.md (0 bytes)
+└── 📁 src/
+    ├── 📁 lib/
+    │   └── 📄 mod.rs (0 bytes)
+    └── 📄 main.rs (0 bytes)
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_with_symlinks() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create various types of entries in mixed order
+        dir.create_sympathlink("path_link", "target/path").await?;
+        dir.find_or_create("subdir", false).await?;
+        dir.find_or_create("regular.txt", true).await?;
+        dir.create_symcidlink("cid_link", Default::default())
+            .await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 subdir/
+├── 🔗 cid_link
+├── 🔗 path_link
+└── 📄 regular.txt (0 bytes)
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_complex_structure() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a complex directory structure with various entity types in mixed order
+        dir.find_or_create("project/src/main.rs", true).await?;
+        dir.create_sympathlink("project/config", "../config")
+            .await?;
+        dir.find_or_create("project/docs/api.md", true).await?;
+        dir.find_or_create("project/src/lib.rs", true).await?;
+        dir.find_or_create("project/docs/examples/basic.rs", true)
+            .await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+└── 📁 project/
+    ├── 📁 docs/
+    │   ├── 📁 examples/
+    │   │   └── 📄 basic.rs (0 bytes)
+    │   └── 📄 api.md (0 bytes)
+    ├── 📁 src/
+    │   ├── 📄 lib.rs (0 bytes)
+    │   └── 📄 main.rs (0 bytes)
+    └── 🔗 config
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_alphabetical_sorting() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create entries in non-alphabetical order
+        dir.find_or_create("z_dir", false).await?;
+        dir.find_or_create("a_dir", false).await?;
+        dir.find_or_create("m_dir", false).await?;
+        dir.find_or_create("z_file.txt", true).await?;
+        dir.find_or_create("a_file.txt", true).await?;
+        dir.create_sympathlink("z_link", "target").await?;
+        dir.create_sympathlink("a_link", "target").await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 a_dir/
+├── 📁 m_dir/
+├── 📁 z_dir/
+├── 📄 a_file.txt (0 bytes)
+├── 🔗 a_link
+├── 📄 z_file.txt (0 bytes)
+└── 🔗 z_link
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod helper {
+    use std::{future::Future, io::Read};
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    /// Helper function to capture stdout during a test
+    pub(super) async fn capture_output<F, Fut>(f: F) -> FsResult<String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = FsResult<()>>,
+    {
+        // Create a temporary file to capture output
+        let temp_file = NamedTempFile::new().unwrap();
+        let temp_file_clone = temp_file.reopen().unwrap();
+
+        // Redirect stdout to the temp file
+        let _guard = gag::Redirect::stdout(temp_file_clone).unwrap();
+
+        // Run the function that produces output
+        f().await?;
+
+        // Drop the guard to ensure output is flushed
+        drop(_guard);
+
+        // Read the captured output
+        let mut output = String::new();
+        let mut file = temp_file.reopen().unwrap();
+        file.read_to_string(&mut output).unwrap();
+        Ok(output)
+    }
+}

--- a/monofs/lib/utils/mod.rs
+++ b/monofs/lib/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Utility functions.
 
+pub mod dir;
 pub mod env;
 pub mod path;
 
@@ -7,5 +8,6 @@ pub mod path;
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use dir::*;
 pub use env::*;
 pub use path::*;

--- a/monoutils-store/Cargo.toml
+++ b/monoutils-store/Cargo.toml
@@ -24,7 +24,6 @@ pretty-error-debug.workspace = true
 ipld-core.workspace = true
 multihash.workspace = true
 multihash-codetable = { workspace = true, features = ["blake3"] }
-lru = "0.12.3"
 serde = { workspace = true, features = ["derive"] }
 serde_ipld_dagcbor.workspace = true
 thiserror.workspace = true
@@ -32,6 +31,6 @@ tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true, features = ["io"] }
 monoutils.workspace = true
 tracing.workspace = true
-
+typed-builder.workspace = true
 [dev-dependencies]
 rand.workspace = true

--- a/monoutils-store/lib/implementations/stores/memstore.rs
+++ b/monoutils-store/lib/implementations/stores/memstore.rs
@@ -71,12 +71,12 @@ where
     blocks: Arc<RwLock<HashMap<Cid, (usize, Bytes)>>>,
 
     /// The chunking algorithm used to split data into chunks.
-    #[builder(default = C::default())]
-    chunker: C,
+    #[builder(default = Arc::new(C::default()))]
+    chunker: Arc<C>,
 
     /// The layout strategy used to store chunked data.
-    #[builder(default = L::default())]
-    layout: L,
+    #[builder(default = Arc::new(L::default()))]
+    layout: Arc<L>,
 }
 
 /// An in-memory storage for IPLD nodes and bytes.
@@ -129,8 +129,8 @@ where
     {
         Self {
             blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker: C::default(),
-            layout: L::default(),
+            chunker: Arc::new(C::default()),
+            layout: Arc::new(L::default()),
         }
     }
 
@@ -387,8 +387,8 @@ where
     fn default() -> Self {
         Self {
             blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker: C::default(),
-            layout: L::default(),
+            chunker: Arc::new(C::default()),
+            layout: Arc::new(L::default()),
         }
     }
 }
@@ -590,18 +590,24 @@ mod tests {
 
         // ======================== Tree Structure ========================
         //
-        //             root[value: 5, rc: 0]
+        //             root[val: 5, rc: 0]
         //                 /            \
         //                /              \
         //               /                \
-        //  middle1[value: 3, rc: 1]      middle2[value: 4, rc: 1]
-        //        /           \                /              \
-        //       /             \              /                \
-        //      /               \            /                  \
-        //  leaf1[value: 1, rc: 1]   leaf2[value: 2, rc: 2]      \
+        //              /                  \
+        //             /                    \
+        // middle1[val: 3, rc: 1]      middle2[val: 4, rc: 1]
+        //        /            \                /          \
+        //       /              \              /            \
+        //      /                \            /              \
+        //     /                  \          /                \
+        //    /                    \        /                  \
+        // leaf1[val: 1, rc: 1]  leaf2[val: 2, rc: 2]           \
+        //     |                           |                     \
         //     |                           |                      \
         //     |                           |                       \
-        //  data1[rc: 1]             data2[rc: 1]            data3[rc: 1]
+        //     |                           |                        \
+        // data1[rc: 1]             data2[rc: 1]             data3[rc: 1]
         //
         // ===============================================================
 

--- a/monoutils-store/lib/implementations/stores/memstore.rs
+++ b/monoutils-store/lib/implementations/stores/memstore.rs
@@ -12,6 +12,7 @@ use monoutils::SeekableReader;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_ipld_dagcbor::codec::DagCborCodec;
 use tokio::{io::AsyncRead, sync::RwLock};
+use typed_builder::TypedBuilder;
 
 use crate::{
     utils, Chunker, Codec, FastCDCChunker, FixedSizeChunker, FlatLayout, IpldReferences, IpldStore,
@@ -34,6 +35,8 @@ use crate::{
 /// - Flexible data layout patterns through the Layout trait
 /// - Reference counting for automatic garbage collection
 ///
+/// ## Reference Counting
+///
 /// The store maintains a reference count for each block, tracking both direct storage and references
 /// from other IPLD nodes. This reference counting is particularly effective for IPLD data since it
 /// forms a directed acyclic graph (DAG), meaning there can never be cyclical references. This
@@ -43,14 +46,20 @@ use crate::{
 /// When a block's reference count reaches zero, it becomes eligible for garbage collection along
 /// with any of its referenced blocks (recursively) that also reach zero references.
 ///
+/// ## Chunking and Layout
+///
+/// The store uses a configurable chunking strategy to split data into smaller blocks. The chunker
+/// is configurable via the `chunker` field. The layout strategy is configurable via the `layout`
+/// field.
+///
 /// [cid]: https://docs.ipfs.tech/concepts/content-addressing/
 /// [ipld]: https://ipld.io/
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TypedBuilder)]
 // TODO: Use `BalancedDagLayout` as default
-pub struct MemoryStore<C = FixedSizeChunker, L = FlatLayout>
+pub struct MemoryStoreImpl<C = FixedSizeChunker, L = FlatLayout>
 where
-    C: Chunker,
-    L: Layout,
+    C: Chunker + Default,
+    L: Layout + Default,
 {
     /// Represents the blocks stored in the store.
     ///
@@ -58,29 +67,59 @@ where
     /// limit, so it is chunked into smaller blocks.
     ///
     /// The `usize` is used for counting the references to blocks within the store.
+    #[builder(default = Arc::new(RwLock::new(HashMap::new())))]
     blocks: Arc<RwLock<HashMap<Cid, (usize, Bytes)>>>,
 
     /// The chunking algorithm used to split data into chunks.
+    #[builder(default = C::default())]
     chunker: C,
 
     /// The layout strategy used to store chunked data.
+    #[builder(default = L::default())]
     layout: L,
 }
 
-/// The default [`MemoryStore`] using [`FastCDCChunker`] and [`FlatLayout`].
-pub type MemoryStoreDefault = MemoryStore<FastCDCChunker, FlatLayout>;
+/// An in-memory storage for IPLD nodes and bytes.
+///
+/// This store provides a thread-safe in-memory implementation for storing [IPLD (InterPlanetary
+/// Linked Data)][ipld] nodes and raw bytes. It supports:
+///
+/// - Storage of both IPLD nodes (DagCbor encoded) and raw bytes
+/// - Content-addressed storage using [CIDs][cid]
+/// - Automatic chunking of large data using configurable chunking strategies
+/// - Flexible data layout patterns through the Layout trait
+/// - Reference counting for automatic garbage collection
+///
+/// ## Reference Counting
+///
+/// The store maintains a reference count for each block, tracking both direct storage and references
+/// from other IPLD nodes. This reference counting is particularly effective for IPLD data since it
+/// forms a directed acyclic graph (DAG), meaning there can never be cyclical references. This
+/// property ensures reference counting will correctly identify unreachable blocks when they are
+/// no longer referenced.
+///
+/// When a block's reference count reaches zero, it becomes eligible for garbage collection along
+/// with any of its referenced blocks (recursively) that also reach zero references.
+///
+/// ## Chunking and Layout
+///
+/// This version of the store uses a [`FastCDCChunker`] for chunking and [`FlatLayout`] for layout.
+///
+/// [cid]: https://docs.ipfs.tech/concepts/content-addressing/
+/// [ipld]: https://ipld.io/
+pub type MemoryStore = MemoryStoreImpl<FastCDCChunker, FlatLayout>;
 
-/// A [`MemoryStore`] with a [`FixedSizeChunker`] and [`FlatLayout`].
-pub type MemoryStoreFixed = MemoryStore<FixedSizeChunker, FlatLayout>;
+/// A [`MemoryStoreImpl`] that uses a [`FixedSizeChunker`] for chunking and [`FlatLayout`] for layout.
+pub type MemoryStoreFixed = MemoryStoreImpl<FixedSizeChunker, FlatLayout>;
 
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
 
-impl<C, L> MemoryStore<C, L>
+impl<C, L> MemoryStoreImpl<C, L>
 where
-    C: Chunker,
-    L: Layout,
+    C: Chunker + Default,
+    L: Layout + Default,
 {
     /// Creates a new `MemoryStore` with default chunker and layout.
     pub fn new() -> Self
@@ -92,15 +131,6 @@ where
             blocks: Arc::new(RwLock::new(HashMap::new())),
             chunker: C::default(),
             layout: L::default(),
-        }
-    }
-
-    /// Creates a new `MemoryStore` with the given `chunker` and `layout`.
-    pub fn with_chunker_and_layout(chunker: C, layout: L) -> Self {
-        MemoryStore {
-            blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker,
-            layout,
         }
     }
 
@@ -144,10 +174,10 @@ where
 //--------------------------------------------------------------------------------------------------
 
 #[async_trait]
-impl<C, L> IpldStore for MemoryStore<C, L>
+impl<C, L> IpldStore for MemoryStoreImpl<C, L>
 where
-    C: Chunker + Clone + Send + Sync + 'static,
-    L: Layout + Clone + Send + Sync + 'static,
+    C: Chunker + Default + Clone + Send + Sync + 'static,
+    L: Layout + Default + Clone + Send + Sync + 'static,
 {
     async fn put_node<T>(&self, node: &T) -> StoreResult<Cid>
     where
@@ -299,10 +329,10 @@ where
 }
 
 #[async_trait]
-impl<C, L> RawStore for MemoryStore<C, L>
+impl<C, L> RawStore for MemoryStoreImpl<C, L>
 where
-    C: Chunker + Clone + Send + Sync,
-    L: Layout + Clone + Send + Sync,
+    C: Chunker + Default + Clone + Send + Sync,
+    L: Layout + Default + Clone + Send + Sync,
 {
     async fn put_raw_block(&self, bytes: impl Into<Bytes> + Send) -> StoreResult<Cid> {
         let bytes = bytes.into();
@@ -336,10 +366,10 @@ where
 }
 
 #[async_trait]
-impl<C, L> IpldStoreSeekable for MemoryStore<C, L>
+impl<C, L> IpldStoreSeekable for MemoryStoreImpl<C, L>
 where
-    C: Chunker + Clone + Send + Sync + 'static,
-    L: LayoutSeekable + Clone + Send + Sync + 'static,
+    C: Chunker + Default + Clone + Send + Sync + 'static,
+    L: LayoutSeekable + Default + Clone + Send + Sync + 'static,
 {
     async fn get_seekable_bytes(
         &self,
@@ -349,12 +379,16 @@ where
     }
 }
 
-impl Default for MemoryStore {
+impl<C, L> Default for MemoryStoreImpl<C, L>
+where
+    C: Chunker + Default,
+    L: Layout + Default,
+{
     fn default() -> Self {
-        MemoryStore {
+        Self {
             blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker: FixedSizeChunker::default(),
-            layout: FlatLayout::default(),
+            chunker: C::default(),
+            layout: L::default(),
         }
     }
 }


### PR DESCRIPTION
- Make reference counting optional in FlatFsStore
- Add TypedBuilder for better store configuration
- Rename FlatFsStoreDefault to FlatFsStore
- Improve documentation for both stores
- Remove LRU dependency
- Simplify store constructors by using builder pattern
- Add tests for disabled reference counting
