### PR TITLE
perf(store): optimize chunker cloning in stores fixing stack overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror 1.0.65",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1147,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -1778,6 +1799,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "gag",
  "getset",
  "hex",
  "intaglio",
@@ -1785,6 +1807,7 @@ dependencies = [
  "monoutils-store",
  "nfsserve",
  "nix",
+ "os_pipe",
  "pin-project-lite",
  "pretty-error-debug",
  "serde",
@@ -2153,6 +2176,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "overload"

--- a/monofs/Cargo.toml
+++ b/monofs/Cargo.toml
@@ -52,3 +52,5 @@ typed-builder.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true
+gag = "1.0"
+os_pipe = "1.1"

--- a/monofs/lib/filesystem/dir.rs
+++ b/monofs/lib/filesystem/dir.rs
@@ -37,7 +37,7 @@ pub const DIR_TYPE_TAG: &str = "monofs.dir";
 /// Entities in `monofs` are designed to be immutable and clone-on-write meaning writes create
 /// forks of the entity.
 #[derive(Clone)]
-pub struct Dir<S>
+pub struct  Dir<S>
 where
     S: IpldStore,
 {

--- a/monofs/lib/filesystem/dir/ops.rs
+++ b/monofs/lib/filesystem/dir/ops.rs
@@ -1079,6 +1079,7 @@ mod tests {
         // Create a complex rename scenario and verify store state
         dir.find_or_create("state_test/source/file.txt", true)
             .await?;
+
         // Create target directory first
         dir.find_or_create("state_test/target", false).await?;
 

--- a/monofs/lib/store/flatfsstore.rs
+++ b/monofs/lib/store/flatfsstore.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::{collections::HashSet, path::PathBuf, pin::Pin};
 
 use async_trait::async_trait;
@@ -111,11 +112,15 @@ where
 {
     #[builder(setter(into))]
     path: PathBuf,
+
     dir_levels: DirLevels,
-    #[builder(default = C::default())]
-    chunker: C,
-    #[builder(default = L::default())]
-    layout: L,
+
+    #[builder(default = Arc::new(C::default()))]
+    chunker: Arc<C>,
+
+    #[builder(default = Arc::new(L::default()))]
+    layout: Arc<L>,
+
     #[builder(default = true)]
     enable_refcount: bool,
 }
@@ -890,18 +895,24 @@ mod tests {
 
         // ======================== Tree Structure ========================
         //
-        //             root[value: 5, rc: 0]
+        //             root[val: 5, rc: 0]
         //                 /            \
         //                /              \
         //               /                \
-        //  middle1[value: 3, rc: 1]      middle2[value: 4, rc: 1]
-        //        /           \                /              \
-        //       /             \              /                \
-        //      /               \            /                  \
-        //  leaf1[value: 1, rc: 1]   leaf2[value: 2, rc: 2]      \
+        //              /                  \
+        //             /                    \
+        // middle1[val: 3, rc: 1]      middle2[val: 4, rc: 1]
+        //        /            \                /          \
+        //       /              \              /            \
+        //      /                \            /              \
+        //     /                  \          /                \
+        //    /                    \        /                  \
+        // leaf1[val: 1, rc: 1]  leaf2[val: 2, rc: 2]           \
+        //     |                           |                     \
         //     |                           |                      \
         //     |                           |                       \
-        //  data1[rc: 1]             data2[rc: 1]            data3[rc: 1]
+        //     |                           |                        \
+        // data1[rc: 1]             data2[rc: 1]             data3[rc: 1]
         //
         // ===============================================================
 

--- a/monofs/lib/utils/dir.rs
+++ b/monofs/lib/utils/dir.rs
@@ -1,0 +1,347 @@
+//! Directory utility functions for monofs.
+//!
+//! This module provides utilities for working with directories in the monofs filesystem,
+//! including functions for displaying directory structures in a tree-like format.
+
+use async_recursion::async_recursion;
+use monoutils_store::IpldStore;
+
+use crate::{filesystem::Dir, FsResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Number of spaces used for each level of indentation
+const INDENT_SIZE: usize = 4;
+
+/// Vertical line character for tree drawing
+const VERTICAL: &str = "│";
+
+/// Branch character for tree drawing (non-last items)
+const BRANCH: &str = "├──";
+
+/// Leaf character for tree drawing (last items)
+const LEAF: &str = "└──";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Prints a visual tree representation of the directory structure.
+///
+/// This function displays the entire directory hierarchy using traditional tree-drawing characters
+/// and visual indicators for different types of entries. The output follows common filesystem
+/// conventions for ordering:
+///
+/// 1. Directories first (with 📁 icon and trailing slash)
+/// 2. Files next (with 📄 icon and size in bytes)
+/// 3. Symbolic links last (with 🔗 icon)
+///
+/// Within each category (directories/files/symlinks), entries are sorted alphabetically.
+///
+/// ## Examples
+///
+/// ```
+/// use monofs::filesystem::Dir;
+/// use monoutils_store::MemoryStore;
+///
+/// # #[tokio::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// let store = MemoryStore::default();
+/// let mut dir = Dir::new(store.clone());
+///
+/// // Create some test files and directories
+/// dir.find_or_create("docs/README.md", true).await?;
+/// dir.find_or_create("src/main.rs", true).await?;
+/// dir.find_or_create("src/lib/mod.rs", true).await?;
+///
+/// // Print the directory tree
+/// print_dir_tree(&dir).await?;
+/// // Output will look like:
+/// // ├── 📁 docs/
+/// // │   └── 📄 README.md (0 bytes)
+/// // └── 📁 src/
+/// //     ├── 📁 lib/
+/// //     │   └── 📄 mod.rs (0 bytes)
+/// //     └── 📄 main.rs (0 bytes)
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Notes
+///
+/// - Uses traditional tree-drawing characters (├──, └──, │)
+/// - File entries include their size in bytes
+/// - Directory entries have a trailing slash
+/// - Symbolic links are marked with a special icon
+/// - Entries are sorted by type first, then alphabetically
+pub async fn print_dir_tree<S>(dir: &Dir<S>) -> FsResult<()>
+where
+    S: IpldStore + Send + Sync,
+{
+    print_dir_tree_with_depth(dir, vec![]).await
+}
+
+/// Internal helper function that implements the recursive tree printing logic.
+///
+/// This function handles the actual work of printing the tree structure using box-drawing
+/// characters. It tracks the prefix for each line to properly draw the tree structure.
+#[async_recursion]
+async fn print_dir_tree_with_depth<S>(dir: &Dir<S>, mut prefix_parts: Vec<bool>) -> FsResult<()>
+where
+    S: IpldStore + Send + Sync,
+{
+    // Collect entries and resolve them first
+    let mut entries: Vec<_> = Vec::new();
+    for (name, link) in dir.get_entries() {
+        let entity = link.resolve_entity(dir.get_store().clone()).await?;
+        entries.push((name, link, entity));
+    }
+
+    // Sort entries: directories first, then alphabetically within each type
+    entries.sort_by(|(name_a, _, entity_a), (name_b, _, entity_b)| {
+        match (entity_a, entity_b) {
+            // Both are directories - sort by name
+            (crate::filesystem::Entity::Dir(_), crate::filesystem::Entity::Dir(_)) => {
+                name_a.cmp(name_b)
+            }
+            // A is directory, B is not - A comes first
+            (crate::filesystem::Entity::Dir(_), _) => std::cmp::Ordering::Less,
+            // B is directory, A is not - B comes first
+            (_, crate::filesystem::Entity::Dir(_)) => std::cmp::Ordering::Greater,
+            // Neither is a directory - sort by name
+            _ => name_a.cmp(name_b),
+        }
+    });
+
+    let total = entries.len();
+
+    for (idx, (name, _, entity)) in entries.into_iter().enumerate() {
+        let is_last = idx == total - 1;
+        let prefix = build_prefix(&prefix_parts);
+        let connector = if is_last { LEAF } else { BRANCH };
+
+        match entity {
+            crate::filesystem::Entity::Dir(subdir) => {
+                println!("{}{} 📁 {}/", prefix, connector, name);
+                prefix_parts.push(!is_last);
+                print_dir_tree_with_depth(&subdir, prefix_parts.clone()).await?;
+                prefix_parts.pop();
+            }
+            crate::filesystem::Entity::File(file) => {
+                let size = file.get_size().await?;
+                println!("{}{} 📄 {} ({} bytes)", prefix, connector, name, size);
+            }
+            _ => println!("{}{} 🔗 {}", prefix, connector, name),
+        }
+    }
+
+    Ok(())
+}
+
+/// Builds the prefix string for a tree line based on the parent levels.
+///
+/// This helper function creates the proper indentation and vertical lines
+/// for each level of the tree.
+fn build_prefix(parts: &[bool]) -> String {
+    parts
+        .iter()
+        .map(|&has_sibling| {
+            if has_sibling {
+                format!("{}{}", VERTICAL, " ".repeat(INDENT_SIZE - 1))
+            } else {
+                " ".repeat(INDENT_SIZE)
+            }
+        })
+        .collect()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use monoutils_store::MemoryStore;
+    use tokio::io::AsyncWriteExt;
+
+    use crate::filesystem::File;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_print_dir_tree_empty_directory() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let dir = Dir::new(store);
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        assert_eq!(output, ""); // Empty directory should produce no output
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_single_file() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a file with some content
+        let mut file = File::new(store);
+        {
+            let mut output = file.get_output_stream();
+            output.write_all(b"test content").await?;
+            output.flush().await?;
+            drop(output);
+        }
+        dir.put_adapted_file("test.txt", file).await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        assert_eq!(output, "└── 📄 test.txt (12 bytes)\n");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_nested_structure() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a nested directory structure with mixed order
+        dir.find_or_create("src/main.rs", true).await?;
+        dir.find_or_create("docs/README.md", true).await?;
+        dir.find_or_create("src/lib/mod.rs", true).await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 docs/
+│   └── 📄 README.md (0 bytes)
+└── 📁 src/
+    ├── 📁 lib/
+    │   └── 📄 mod.rs (0 bytes)
+    └── 📄 main.rs (0 bytes)
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_with_symlinks() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create various types of entries in mixed order
+        dir.create_sympathlink("path_link", "target/path").await?;
+        dir.find_or_create("subdir", false).await?;
+        dir.find_or_create("regular.txt", true).await?;
+        dir.create_symcidlink("cid_link", Default::default())
+            .await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 subdir/
+├── 🔗 cid_link
+├── 🔗 path_link
+└── 📄 regular.txt (0 bytes)
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_complex_structure() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create a complex directory structure with various entity types in mixed order
+        dir.find_or_create("project/src/main.rs", true).await?;
+        dir.create_sympathlink("project/config", "../config")
+            .await?;
+        dir.find_or_create("project/docs/api.md", true).await?;
+        dir.find_or_create("project/src/lib.rs", true).await?;
+        dir.find_or_create("project/docs/examples/basic.rs", true)
+            .await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+└── 📁 project/
+    ├── 📁 docs/
+    │   ├── 📁 examples/
+    │   │   └── 📄 basic.rs (0 bytes)
+    │   └── 📄 api.md (0 bytes)
+    ├── 📁 src/
+    │   ├── 📄 lib.rs (0 bytes)
+    │   └── 📄 main.rs (0 bytes)
+    └── 🔗 config
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_print_dir_tree_alphabetical_sorting() -> FsResult<()> {
+        let store = MemoryStore::default();
+        let mut dir = Dir::new(store.clone());
+
+        // Create entries in non-alphabetical order
+        dir.find_or_create("z_dir", false).await?;
+        dir.find_or_create("a_dir", false).await?;
+        dir.find_or_create("m_dir", false).await?;
+        dir.find_or_create("z_file.txt", true).await?;
+        dir.find_or_create("a_file.txt", true).await?;
+        dir.create_sympathlink("z_link", "target").await?;
+        dir.create_sympathlink("a_link", "target").await?;
+
+        let output = helper::capture_output(|| async { print_dir_tree(&dir).await }).await?;
+        let expected = "\
+├── 📁 a_dir/
+├── 📁 m_dir/
+├── 📁 z_dir/
+├── 📄 a_file.txt (0 bytes)
+├── 🔗 a_link
+├── 📄 z_file.txt (0 bytes)
+└── 🔗 z_link
+";
+        assert_eq!(output, expected);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod helper {
+    use std::{future::Future, io::Read};
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    /// Helper function to capture stdout during a test
+    pub(super) async fn capture_output<F, Fut>(f: F) -> FsResult<String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = FsResult<()>>,
+    {
+        // Create a temporary file to capture output
+        let temp_file = NamedTempFile::new().unwrap();
+        let temp_file_clone = temp_file.reopen().unwrap();
+
+        // Redirect stdout to the temp file
+        let _guard = gag::Redirect::stdout(temp_file_clone).unwrap();
+
+        // Run the function that produces output
+        f().await?;
+
+        // Drop the guard to ensure output is flushed
+        drop(_guard);
+
+        // Read the captured output
+        let mut output = String::new();
+        let mut file = temp_file.reopen().unwrap();
+        file.read_to_string(&mut output).unwrap();
+        Ok(output)
+    }
+}

--- a/monofs/lib/utils/mod.rs
+++ b/monofs/lib/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Utility functions.
 
+pub mod dir;
 pub mod env;
 pub mod path;
 
@@ -7,5 +8,6 @@ pub mod path;
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use dir::*;
 pub use env::*;
 pub use path::*;

--- a/monoutils-store/lib/implementations/stores/memstore.rs
+++ b/monoutils-store/lib/implementations/stores/memstore.rs
@@ -71,12 +71,12 @@ where
     blocks: Arc<RwLock<HashMap<Cid, (usize, Bytes)>>>,
 
     /// The chunking algorithm used to split data into chunks.
-    #[builder(default = C::default())]
-    chunker: C,
+    #[builder(default = Arc::new(C::default()))]
+    chunker: Arc<C>,
 
     /// The layout strategy used to store chunked data.
-    #[builder(default = L::default())]
-    layout: L,
+    #[builder(default = Arc::new(L::default()))]
+    layout: Arc<L>,
 }
 
 /// An in-memory storage for IPLD nodes and bytes.
@@ -129,8 +129,8 @@ where
     {
         Self {
             blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker: C::default(),
-            layout: L::default(),
+            chunker: Arc::new(C::default()),
+            layout: Arc::new(L::default()),
         }
     }
 
@@ -387,8 +387,8 @@ where
     fn default() -> Self {
         Self {
             blocks: Arc::new(RwLock::new(HashMap::new())),
-            chunker: C::default(),
-            layout: L::default(),
+            chunker: Arc::new(C::default()),
+            layout: Arc::new(L::default()),
         }
     }
 }
@@ -590,18 +590,24 @@ mod tests {
 
         // ======================== Tree Structure ========================
         //
-        //             root[value: 5, rc: 0]
+        //             root[val: 5, rc: 0]
         //                 /            \
         //                /              \
         //               /                \
-        //  middle1[value: 3, rc: 1]      middle2[value: 4, rc: 1]
-        //        /           \                /              \
-        //       /             \              /                \
-        //      /               \            /                  \
-        //  leaf1[value: 1, rc: 1]   leaf2[value: 2, rc: 2]      \
+        //              /                  \
+        //             /                    \
+        // middle1[val: 3, rc: 1]      middle2[val: 4, rc: 1]
+        //        /            \                /          \
+        //       /              \              /            \
+        //      /                \            /              \
+        //     /                  \          /                \
+        //    /                    \        /                  \
+        // leaf1[val: 1, rc: 1]  leaf2[val: 2, rc: 2]           \
+        //     |                           |                     \
         //     |                           |                      \
         //     |                           |                       \
-        //  data1[rc: 1]             data2[rc: 1]            data3[rc: 1]
+        //     |                           |                        \
+        // data1[rc: 1]             data2[rc: 1]             data3[rc: 1]
         //
         // ===============================================================
 


### PR DESCRIPTION
Fix stack overflow in test_ops_rename by wrapping chunkers and layouts in Arc to avoid expensive cloning in MemoryStore and FlatFsStore. This significantly improves performance for deep recursive operations.

Key changes:
- Fix potential stack overflow in directory rename operations
- Wrap chunkers and layouts in Arc in MemoryStore and FlatFsStore
- Update FastCDC and GearCDC to use Arc for gear tables
- Add directory tree visualization utility as a bonus feature

The performance improvement is particularly noticeable in deep recursive operations like directory renames, where multiple store clones were previously occurring.
